### PR TITLE
feat: graceful shutdown and auto-resume (#18)

### DIFF
--- a/.planning/phases/07-shutdown-resume/07-01-PLAN.md
+++ b/.planning/phases/07-shutdown-resume/07-01-PLAN.md
@@ -1,0 +1,119 @@
+---
+plan_id: "07-01"
+title: "Shutdown Coordinator Module"
+phase: 7
+wave: 1
+depends_on: []
+files_modified:
+  - src/shutdown.ts
+  - src/types.ts
+autonomous: true
+requirements_addressed:
+  - "AC: q press scheduler stops assigning new work"
+  - "AC: double q within 2s or Ctrl+C SIGTERM all workers"
+  - "AC: status files written with step_result interrupted"
+---
+
+## Objective
+
+Create the `src/shutdown.ts` module -- the centralized coordinator for file-based IPC shutdown signaling. This module provides read/write/poll/clear operations for the `.orchestrator/shutdown` signal file, plus an `ActiveWorkerRegistry` for tracking spawned worker PIDs so force shutdown can kill them all.
+
+Also extend `src/types.ts` with `ShutdownMode`, `ShutdownSignal`, and add `shouldShutdown` to `SchedulerDeps`.
+
+## Tasks
+
+### Task 1: Extend types.ts with shutdown types and SchedulerDeps addition
+
+<read_first>
+- src/types.ts (full file -- understand existing types, SchedulerDeps interface at line 121-147)
+</read_first>
+
+<action>
+Add these types to `src/types.ts` AFTER the `MergeDetectorHandle` interface (end of file):
+
+```typescript
+// --- Shutdown types ---
+
+export type ShutdownMode = 'graceful' | 'force';
+
+export interface ShutdownSignal {
+  readonly mode: ShutdownMode;
+  readonly requested_at: string;
+}
+```
+
+Add `shouldShutdown` to the `SchedulerDeps` interface as the LAST field:
+
+```typescript
+readonly shouldShutdown?: () => ShutdownSignal | null;
+```
+
+This is optional (`?`) so existing callers (tests, orchestrate.ts) continue to compile without changes. The scheduler will call `deps.shouldShutdown?.()` with optional chaining.
+</action>
+
+<acceptance_criteria>
+- `grep -c "export type ShutdownMode" src/types.ts` returns 1
+- `grep -c "export interface ShutdownSignal" src/types.ts` returns 1
+- `grep -c "readonly shouldShutdown" src/types.ts` returns 1
+- `pnpm run check` passes (no type errors)
+</acceptance_criteria>
+
+### Task 2: Create src/shutdown.ts -- shutdown coordinator module
+
+<read_first>
+- src/types.ts (to use ShutdownMode, ShutdownSignal types just added)
+- src/status-manager.ts lines 66-75 (atomic write pattern: tmp+rename)
+- src/lock.ts lines 4-6 (path resolution pattern with baseDir)
+- src/worker-manager.ts lines 208-250 (killWorker function signature)
+</read_first>
+
+<action>
+Create `src/shutdown.ts` with these exports:
+
+1. **`getShutdownPath(baseDir?: string): string`** -- returns `path.resolve(baseDir ?? '.', '.orchestrator/shutdown')`
+
+2. **`writeShutdownFile(mode: ShutdownMode, baseDir?: string): void`** -- atomic write via tmp+rename (same as status-manager.ts:72-74). File content: `{"mode": "<mode>", "requested_at": "<ISO timestamp>"}` with tab-indented JSON. Create directory with `mkdirSync({ recursive: true })`.
+
+3. **`readShutdownFile(baseDir?: string): ShutdownSignal | null`** -- try/catch readFileSync + JSON.parse. Validate `mode` is `'graceful'` or `'force'`. Return null on any error or invalid data.
+
+4. **`clearShutdownFile(baseDir?: string): void`** -- unlinkSync wrapped in try/catch, ignoring ENOENT.
+
+5. **`createWorkerRegistry(): WorkerRegistry`** -- returns object with:
+   - `register(pid: number): void` -- adds pid to internal `Set<number>`
+   - `deregister(pid: number): void` -- removes pid from set
+   - `getActivePids(): readonly number[]` -- returns `Array.from(set)`
+   
+   Type: `export interface WorkerRegistry { readonly register: (pid: number) => void; readonly deregister: (pid: number) => void; readonly getActivePids: () => readonly number[]; }`
+
+6. **`async forceKillAll(registry: WorkerRegistry, killWorker: (pid: number) => Promise<void>): Promise<void>`** -- calls `Promise.allSettled(registry.getActivePids().map(pid => killWorker(pid)))`. This delegates to the existing `killWorker` from worker-manager.ts (SIGTERM -> 5s -> SIGKILL).
+
+Import types from `./types.js`. Use `node:fs` and `node:path`.
+</action>
+
+<acceptance_criteria>
+- `grep -c "export function writeShutdownFile" src/shutdown.ts` returns 1
+- `grep -c "export function readShutdownFile" src/shutdown.ts` returns 1
+- `grep -c "export function clearShutdownFile" src/shutdown.ts` returns 1
+- `grep -c "export function createWorkerRegistry" src/shutdown.ts` returns 1
+- `grep -c "export async function forceKillAll" src/shutdown.ts` returns 1
+- `grep -c "export interface WorkerRegistry" src/shutdown.ts` returns 1
+- `grep -c "\.tmp" src/shutdown.ts` returns at least 1 (atomic write pattern)
+- `grep -c "renameSync" src/shutdown.ts` returns 1 (atomic write)
+- `pnpm run check` passes
+- `pnpm run build` passes
+</acceptance_criteria>
+
+## Verification
+
+```bash
+pnpm run check && pnpm run build
+```
+
+## must_haves
+
+- `src/shutdown.ts` exists with all 6 exports (getShutdownPath, writeShutdownFile, readShutdownFile, clearShutdownFile, createWorkerRegistry, forceKillAll)
+- `src/types.ts` has ShutdownMode, ShutdownSignal, and shouldShutdown on SchedulerDeps
+- Atomic write pattern used (tmp+rename) in writeShutdownFile
+- WorkerRegistry tracks PIDs in a Set with register/deregister/getActivePids
+- forceKillAll delegates to injected killWorker (does not import worker-manager directly)
+- No mutation of external state -- WorkerRegistry encapsulates its own Set

--- a/.planning/phases/07-shutdown-resume/07-01-SUMMARY.md
+++ b/.planning/phases/07-shutdown-resume/07-01-SUMMARY.md
@@ -1,0 +1,92 @@
+---
+phase: 7
+plan: "07-01"
+subsystem: shutdown
+tags:
+  - shutdown
+  - ipc
+  - file-based-signaling
+  - worker-registry
+dependency_graph:
+  requires: []
+  provides:
+    - ShutdownMode type
+    - ShutdownSignal interface
+    - shouldShutdown on SchedulerDeps
+    - shutdown coordinator module (read/write/poll/clear)
+    - WorkerRegistry interface
+    - forceKillAll function
+  affects:
+    - src/types.ts
+tech_stack:
+  added: []
+  patterns:
+    - atomic-write-tmp-rename
+    - dependency-injection-callback
+    - encapsulated-set-registry
+key_files:
+  created:
+    - src/shutdown.ts
+  modified:
+    - src/types.ts
+decisions:
+  - "WorkerRegistry uses encapsulated Set with register/deregister/getActivePids -- no external mutation"
+  - "forceKillAll accepts injected killWorker callback instead of importing worker-manager directly"
+  - "readShutdownFile validates mode strictly, returns null on any parse or validation error"
+  - "writeShutdownFile uses tab-indented JSON with trailing newline matching status-manager pattern"
+metrics:
+  duration_seconds: 89
+  completed: "2026-05-03T16:11:32Z"
+  tasks_completed: 2
+  tasks_total: 2
+  files_created: 1
+  files_modified: 1
+---
+
+# Phase 7 Plan 01: Shutdown Coordinator Module Summary
+
+Shutdown coordinator module with file-based IPC signaling and worker PID registry for graceful/force shutdown orchestration.
+
+## Tasks Completed
+
+| Task | Name | Commit | Key Changes |
+|------|------|--------|-------------|
+| 1 | Extend types.ts with shutdown types | d72c8c6 | Added ShutdownMode, ShutdownSignal, shouldShutdown on SchedulerDeps |
+| 2 | Create src/shutdown.ts | 8ad11e3 | 6 exports: getShutdownPath, writeShutdownFile, readShutdownFile, clearShutdownFile, createWorkerRegistry, forceKillAll |
+
+## Implementation Details
+
+### Types (src/types.ts)
+
+- `ShutdownMode`: Union type `'graceful' | 'force'`
+- `ShutdownSignal`: Readonly interface with `mode` and `requested_at` fields
+- `shouldShutdown`: Optional callback on `SchedulerDeps` returning `ShutdownSignal | null`; callers use `deps.shouldShutdown?.()` with optional chaining
+
+### Shutdown Coordinator (src/shutdown.ts)
+
+- `getShutdownPath(baseDir?)`: Resolves `.orchestrator/shutdown` path
+- `writeShutdownFile(mode, baseDir?)`: Atomic write via tmp+rename, tab-indented JSON
+- `readShutdownFile(baseDir?)`: Safe read with strict mode validation, null on any error
+- `clearShutdownFile(baseDir?)`: Unlink with ENOENT suppression
+- `createWorkerRegistry()`: Encapsulated Set-based PID tracker with register/deregister/getActivePids
+- `forceKillAll(registry, killWorker)`: Promise.allSettled over all active PIDs, delegates to injected killWorker
+
+## Verification
+
+```
+pnpm run check: Checked 68 files -- no errors
+pnpm run build: ESM build success
+```
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 1 - Bug] Biome formatting for Promise.allSettled call**
+- **Found during:** Task 2
+- **Issue:** Biome formatter expected single-line `Promise.allSettled(registry.getActivePids().map(...))` instead of multi-line
+- **Fix:** Collapsed to single line to match project formatter rules
+- **Files modified:** src/shutdown.ts
+- **Commit:** 8ad11e3
+
+## Self-Check: PASSED

--- a/.planning/phases/07-shutdown-resume/07-02-PLAN.md
+++ b/.planning/phases/07-shutdown-resume/07-02-PLAN.md
@@ -1,0 +1,90 @@
+---
+plan_id: "07-02"
+title: "Resume Module"
+phase: 7
+wave: 1
+depends_on: []
+files_modified:
+  - src/resume.ts
+autonomous: true
+requirements_addressed:
+  - "AC: auto-resume on orchestrator start reads status JSON"
+  - "AC: resume cross-references with git -- no commit re-run"
+  - "AC: resume cross-references with git -- confirmed commit skip"
+---
+
+## Objective
+
+Create `src/resume.ts` -- the resume logic module that detects existing state, reconciles with git, detects merged PRs via `gh pr list`, and resets statuses to safe checkpoints using the decision tree from CONTEXT.md.
+
+## Tasks
+
+### Task 1: Create src/resume.ts -- resume detection and checkpoint reset
+
+<read_first>
+- src/status-manager.ts (readGroupStatus, reconcile function at lines 138-195, writeGroupStatus)
+- src/types.ts (GroupStatus, GroupStep, GitBranchState, ReconcileCorrection, SchedulerDeps, ExecResult)
+- .planning/phases/07-shutdown-resume/07-CONTEXT.md (resume decision tree under "Resume: Reset to Last Safe Checkpoint")
+</read_first>
+
+<action>
+Create `src/resume.ts` with these exports:
+
+1. **`hasExistingState(baseDir?: string): boolean`** -- checks if `.orchestrator/status` directory exists AND contains at least one `.json` file. Use `existsSync` + `readdirSync` + `.some(f => f.endsWith('.json'))`.
+
+2. **`interface ResumeResult { readonly corrections: readonly ReconcileCorrection[]; readonly mergedBranches: readonly string[]; readonly resetGroups: readonly string[]; }`**
+
+3. **`async function detectMergedPRs(statuses: readonly GroupStatus[], execCommand: (cmd: string, args: readonly string[], cwd: string) => Promise<ExecResult>): Promise<readonly string[]>`**
+   - For each status where `step === 'awaiting-merge'`, run: `execCommand('gh', ['pr', 'list', '--head', status.branch, '--json', 'number,state', '--state', 'merged'], '.')`
+   - Parse JSON output. If result array is non-empty (has a merged PR), add `status.branch` to merged list.
+   - Wrap each call in try/catch -- if `gh` fails, skip that branch (log warning to stderr).
+   - Return array of branch names that have merged PRs.
+
+4. **`function resetToCheckpoint(status: GroupStatus, mergedBranches: ReadonlySet<string>, now: () => string): GroupStatus`**
+   Apply the CONTEXT.md resume decision tree:
+   - `step === 'idle' && step_result === 'pass'` AND `issues_remaining.length === 0` --> all issues done, restart from self-review: return `{ ...status, step: 'idle', step_result: '', current_issue: null, last_updated: now() }`
+   - `step in ['reviewing', 'pr-creating', 'pr-reviewing']` --> died mid-phase: return `{ ...status, step: 'idle', step_result: '', current_issue: null, last_updated: now() }`
+   - `step === 'awaiting-merge'` AND `mergedBranches.has(status.branch)` --> PR merged: return `{ ...status, step: 'idle', step_result: 'pass', current_issue: null, issues_remaining: [], last_updated: now() }` (mark fully done)
+   - `step === 'awaiting-merge'` AND NOT merged --> keep as-is (will re-enter merge wait)
+   - `step in ['coding', 'cloning', 'verifying']` --> died mid-issue: return `{ ...status, step: 'idle', step_result: '', last_updated: now() }` (current_issue stays so it gets retried, it's still in issues_remaining)
+   - `step === 'idle' && step_result === 'interrupted'` --> was shut down gracefully: return `{ ...status, step: 'idle', step_result: '', last_updated: now() }`
+   - Default: return status unchanged.
+
+5. **`async function resumeFromState(gitState: GitBranchState, execCommand: (cmd: string, args: readonly string[], cwd: string) => Promise<ExecResult>, baseDir?: string, now?: () => string): Promise<ResumeResult>`**
+   - Call `reconcile(gitState, baseDir, now)` from status-manager.ts to get corrections
+   - Read all status files from `.orchestrator/status/` directory
+   - Call `detectMergedPRs(statuses, execCommand)` for awaiting-merge groups
+   - Build `mergedSet = new Set(mergedBranches)`
+   - For each status, call `resetToCheckpoint(status, mergedSet, now)` -- if result differs from original, write it back via `writeGroupStatus`
+   - Return `{ corrections, mergedBranches, resetGroups }`
+
+Import `reconcile`, `readGroupStatus`, `writeGroupStatus` from `./status-manager.js`. Import types from `./types.js`.
+</action>
+
+<acceptance_criteria>
+- `grep -c "export function hasExistingState" src/resume.ts` returns 1
+- `grep -c "export interface ResumeResult" src/resume.ts` returns 1
+- `grep -c "export async function detectMergedPRs" src/resume.ts` returns 1
+- `grep -c "export function resetToCheckpoint" src/resume.ts` returns 1
+- `grep -c "export async function resumeFromState" src/resume.ts` returns 1
+- `grep -c "gh.*pr.*list" src/resume.ts` returns at least 1
+- `grep -c "reconcile" src/resume.ts` returns at least 1
+- `pnpm run check` passes
+- `pnpm run build` passes
+</acceptance_criteria>
+
+## Verification
+
+```bash
+pnpm run check && pnpm run build
+```
+
+## must_haves
+
+- `src/resume.ts` exists with all 5 exports
+- `hasExistingState` checks for `.orchestrator/status/*.json` files
+- `detectMergedPRs` uses `gh pr list --head <branch> --state merged` pattern
+- `resetToCheckpoint` implements all 6 branches of the CONTEXT.md decision tree
+- `resumeFromState` calls reconcile first, then detectMergedPRs, then resetToCheckpoint per group
+- Pure function for resetToCheckpoint (returns new object, does not mutate input)
+- All async operations (gh calls) wrapped in try/catch with stderr warnings on failure

--- a/.planning/phases/07-shutdown-resume/07-02-SUMMARY.md
+++ b/.planning/phases/07-shutdown-resume/07-02-SUMMARY.md
@@ -1,0 +1,71 @@
+---
+phase: 7
+plan: 2
+subsystem: resume
+tags:
+  - resume
+  - reconcile
+  - checkpoint-reset
+  - merged-pr-detection
+dependency_graph:
+  requires: []
+  provides:
+    - resume-module
+    - checkpoint-reset-logic
+    - merged-pr-detection
+  affects:
+    - src/resume.ts
+tech_stack:
+  added: []
+  patterns:
+    - immutable-status-updates
+    - dependency-injection-via-function-params
+key_files:
+  created:
+    - src/resume.ts
+  modified: []
+decisions:
+  - "Used reference equality (reset !== original) to detect checkpoint changes, avoiding deep comparison overhead"
+  - "Kept current_issue intact for mid-issue deaths (coding/cloning/verifying) so issue is retried from issues_remaining"
+metrics:
+  duration: "~2 minutes"
+  completed: "2026-05-03T16:12:32Z"
+---
+
+# Phase 7 Plan 2: Resume Module Summary
+
+Resume module with checkpoint reset logic, merged PR detection via gh CLI, and full reconcile-then-reset orchestration flow.
+
+## What Was Built
+
+Created `src/resume.ts` with 5 exports implementing the CONTEXT.md resume decision tree:
+
+1. **`hasExistingState(baseDir?)`** -- checks `.orchestrator/status/` for any `.json` files to detect resumable state
+2. **`ResumeResult` interface** -- captures corrections from reconcile, merged branches, and reset groups
+3. **`detectMergedPRs(statuses, execCommand)`** -- queries `gh pr list --head <branch> --state merged` for each awaiting-merge group, with try/catch + stderr warnings on failure
+4. **`resetToCheckpoint(status, mergedBranches, now)`** -- pure function implementing all 6 branches of the decision tree:
+   - idle+pass with no remaining issues: reset to re-run self-review
+   - reviewing/pr-creating/pr-reviewing: died mid-phase, reset to idle
+   - awaiting-merge + merged: mark fully done (issues_remaining cleared)
+   - awaiting-merge + not merged: keep as-is
+   - coding/cloning/verifying: died mid-issue, reset step but keep current_issue for retry
+   - idle + interrupted: clear interrupted flag
+5. **`resumeFromState(gitState, execCommand, baseDir?, now?)`** -- orchestrates the full resume flow: reconcile with git, read statuses, detect merged PRs, reset each to checkpoint, write back changed statuses
+
+## Deviations from Plan
+
+None -- plan executed exactly as written.
+
+## Commits
+
+| Task | Commit | Description |
+|------|--------|-------------|
+| 1 | dc0779c | Create resume module with checkpoint reset logic |
+
+## Self-Check: PASSED
+
+- [x] src/resume.ts exists (4813 bytes)
+- [x] Commit dc0779c verified in git log
+- [x] pnpm run check passes
+- [x] pnpm run build passes
+- [x] All 5 exports present (hasExistingState, ResumeResult, detectMergedPRs, resetToCheckpoint, resumeFromState)

--- a/.planning/phases/07-shutdown-resume/07-03-PLAN.md
+++ b/.planning/phases/07-shutdown-resume/07-03-PLAN.md
@@ -1,0 +1,390 @@
+---
+plan_id: "07-03"
+title: "Core Integration: Scheduler Shutdown Check + Signal Handlers + Orchestrate Wiring + CLI Resume"
+phase: 7
+wave: 2
+depends_on: ["07-01", "07-02"]
+files_modified:
+  - src/scheduler.ts
+  - src/types.ts
+  - src/lock.ts
+  - src/orchestrate.ts
+  - src/cli.tsx
+autonomous: true
+requirements_addressed:
+  - "AC: q press scheduler stops assigning new work"
+  - "AC: running workers finish current step not interrupted mid-step"
+  - "AC: status files written with step_result interrupted"
+  - "AC: context files for current issues persist"
+  - "AC: lock file released on exit"
+  - "AC: force kill writes best-effort status"
+  - "AC: SIGTERM/SIGINT handlers registered for cleanup"
+  - "AC: auto-resume on orchestrator start"
+  - "AC: resume cross-references with git"
+---
+
+## Objective
+
+Wire the shutdown coordinator and resume module into the existing scheduler loop, signal handlers, orchestrate entry point, and CLI. Split into 4 focused tasks: (a) scheduler shutdown check, (b) lock.ts signal handler enhancement, (c) orchestrate.ts shutdown+resume wiring, (d) cli.tsx resume detection.
+
+## Tasks
+
+### Task 1: Add shutdown check to scheduler.ts processGroup loop
+
+<read_first>
+- src/scheduler.ts (full file — especially processGroup at lines 218-416, the for loop at line 248)
+- src/types.ts (SchedulerDeps, GroupResult, ShutdownSignal)
+- src/shutdown.ts (readShutdownFile — to understand what shouldShutdown returns)
+</read_first>
+
+<action>
+**A. Modify `src/types.ts`** — add `shutdown` to GroupResult and `shouldShutdown` to SchedulerDeps:
+
+Add to `GroupResult` interface:
+```typescript
+readonly shutdown?: boolean;
+```
+
+Add to `SchedulerDeps` interface:
+```typescript
+readonly shouldShutdown?: () => ShutdownSignal | null;
+```
+
+**B. Modify `src/scheduler.ts`** — add shutdown check inside processGroup's `for` loop.
+
+Add this block at the START of the for loop body in `processGroup` (line 248, before `const result = await processIssue(...)`):
+
+```typescript
+// Shutdown checkpoint — between issues only (per design: no mid-step interruption)
+const shutdownSignal = deps.shouldShutdown?.();
+if (shutdownSignal) {
+  safeWriteStatus(deps, slug, {
+    ...freshStatus(slug, group, deps, now),
+    current_issue: null,
+    step: 'idle',
+    step_result: 'interrupted',
+    last_updated: now(),
+  });
+  return { completed: false, shutdown: true, error: `shutdown requested (${shutdownSignal.mode})` };
+}
+```
+
+In `assignWork`, after `Promise.allSettled` resolves, map `shutdown` through to `GroupResult`:
+
+```typescript
+// In the results mapping (line 452-468), add shutdown field:
+return {
+  pr_number: group.pr_number,
+  branch: group.branch,
+  ...result,
+  // shutdown is already spread from result if present
+};
+```
+
+No additional changes needed — `shutdown` is already in `result` via the spread.
+</action>
+
+<acceptance_criteria>
+- `grep -c "deps.shouldShutdown" src/scheduler.ts` returns at least 1
+- `grep -c "step_result: 'interrupted'" src/scheduler.ts` returns at least 1
+- `grep -c "shutdown requested" src/scheduler.ts` returns at least 1
+- `grep "readonly shutdown" src/types.ts | grep -c "boolean"` returns at least 1
+- `grep "readonly shouldShutdown" src/types.ts | grep -c "ShutdownSignal"` returns at least 1
+- `pnpm run check` passes
+</acceptance_criteria>
+
+### Task 2: Enhance lock.ts signal handlers
+
+<read_first>
+- src/lock.ts (full file — installSignalHandlers at lines 79-90)
+</read_first>
+
+<action>
+Modify `src/lock.ts` — change `installSignalHandlers` to accept an `onShutdown` callback:
+
+```typescript
+export function installSignalHandlers(
+  onShutdown?: () => void,
+  baseDir?: string,
+): void {
+  let shuttingDown = false;
+
+  const signalHandler = () => {
+    if (shuttingDown) return; // Prevent re-entrancy (RESEARCH.md pitfall #1)
+    shuttingDown = true;
+    if (onShutdown) {
+      onShutdown();
+    } else {
+      // Fallback: release lock and exit (backward compat)
+      releaseLock(baseDir);
+      process.exit(0);
+    }
+  };
+
+  process.once('SIGINT', signalHandler);
+  process.once('SIGTERM', signalHandler);
+  process.once('exit', () => {
+    releaseLock(baseDir);
+  });
+}
+```
+
+Key changes:
+1. Added `onShutdown` callback parameter (first position, `baseDir` moves to second)
+2. Added `shuttingDown` re-entrancy guard
+3. When `onShutdown` provided, delegate to it instead of hard-exiting
+4. When no callback (backward compat), same behavior as before
+</action>
+
+<acceptance_criteria>
+- `grep -c "shuttingDown" src/lock.ts` returns at least 2 (declaration + check)
+- `grep -c "onShutdown" src/lock.ts` returns at least 3 (param + check + call)
+- `grep "installSignalHandlers" src/lock.ts | head -1` shows `onShutdown?: () => void` parameter
+- `pnpm run check` passes
+</acceptance_criteria>
+
+### Task 3: Wire shutdown + resume into orchestrate.ts
+
+<read_first>
+- src/orchestrate.ts (full file — orchestrate function, buildRealDeps, OrchestrateOverrides, wrapWithProgress)
+- src/shutdown.ts (clearShutdownFile, readShutdownFile, createWorkerRegistry, forceKillAll, WorkerRegistry)
+- src/resume.ts (hasExistingState, resumeFromState, ResumeResult)
+- src/types.ts (SchedulerDeps, WorkerEvent, OrchestratorConfig, PlanData)
+- src/worker-manager.ts (spawnWorker, spawnDirectWorker signatures)
+</read_first>
+
+<action>
+**A. Add imports:**
+```typescript
+import { clearShutdownFile, createWorkerRegistry, forceKillAll, readShutdownFile } from './shutdown.js';
+import { hasExistingState, resumeFromState } from './resume.js';
+import type { WorkerEvent, WorkerHandle } from './types.js'; // if not already imported
+```
+
+**B. Add `onShutdown` to OrchestrateOverrides:**
+```typescript
+export interface OrchestrateOverrides {
+  readonly loadConfig?: () => OrchestratorConfig;
+  readonly parsePlan?: (filePath: string) => Promise<PlanData>;
+  readonly deps?: SchedulerDeps;
+  readonly onShutdown?: (mode: 'graceful' | 'force') => void;
+}
+```
+
+**C. Create worker spawn wrappers for PID registry tracking:**
+
+Add these helper functions (before `orchestrate`):
+
+```typescript
+function wrapSpawnWorker(
+  original: SchedulerDeps['spawnWorker'],
+  registry: ReturnType<typeof createWorkerRegistry>,
+): SchedulerDeps['spawnWorker'] {
+  return (issue, groupSlug, worktreePath, onEvent, contextContent?) => {
+    const wrappedOnEvent = (event: WorkerEvent): void => {
+      if (event.event === 'exited') {
+        registry.deregister(handle.pid);
+      }
+      onEvent(event);
+    };
+    const handle = original(issue, groupSlug, worktreePath, wrappedOnEvent, contextContent);
+    registry.register(handle.pid);
+    return handle;
+  };
+}
+
+function wrapSpawnDirectWorker(
+  original: SchedulerDeps['spawnDirectWorker'],
+  registry: ReturnType<typeof createWorkerRegistry>,
+): SchedulerDeps['spawnDirectWorker'] {
+  return (id, groupSlug, worktreePath, onEvent, prompt) => {
+    const wrappedOnEvent = (event: WorkerEvent): void => {
+      if (event.event === 'exited') {
+        registry.deregister(handle.pid);
+      }
+      onEvent(event);
+    };
+    const handle = original(id, groupSlug, worktreePath, wrappedOnEvent, prompt);
+    registry.register(handle.pid);
+    return handle;
+  };
+}
+```
+
+**D. Modify `orchestrate()` function body:**
+
+BEFORE the `assignWork` call, add:
+
+```typescript
+// Create worker PID registry for force shutdown
+const registry = createWorkerRegistry();
+
+// Clear stale shutdown file from previous run (RESEARCH.md pitfall #3)
+clearShutdownFile();
+
+// Build shouldShutdown callback for scheduler
+const shouldShutdown = () => readShutdownFile();
+
+// Resume detection: reconcile state with git before scheduling
+const mergedPRs = new Set<number>();
+if (hasExistingState()) {
+  onProgress('Resuming from previous state — reconciling with git...');
+  const resumeResult = await resumeFromState({ execCommand: rawDeps.execCommand ?? realExecCommand });
+  for (const correction of resumeResult.corrections) {
+    onProgress(`  Reconciled: ${correction.slug} — ${correction.reason}`);
+  }
+  // Populate mergedPRs from resume results — map merged branches to PR numbers
+  for (const mergedBranch of resumeResult.mergedBranches) {
+    const matchingGroup = plan.groups.find((g) => g.branch === mergedBranch);
+    if (matchingGroup) {
+      mergedPRs.add(matchingGroup.pr_number);
+      onProgress(`  Already merged: PR #${matchingGroup.pr_number} (${mergedBranch})`);
+    }
+  }
+}
+
+// Wire shutdown + registry into deps
+const trackedDeps: SchedulerDeps = {
+  ...deps,
+  shouldShutdown,
+  spawnWorker: wrapSpawnWorker(deps.spawnWorker, registry),
+  spawnDirectWorker: wrapSpawnDirectWorker(deps.spawnDirectWorker, registry),
+};
+```
+
+Replace the existing `return assignWork(plan, mergedPRs, config, deps);` with:
+
+```typescript
+const result = await assignWork(plan, mergedPRs, config, trackedDeps);
+
+// Check if any group was interrupted by shutdown
+const shutdownGroup = result.results.find((r) => r.shutdown);
+if (shutdownGroup) {
+  const signal = readShutdownFile();
+  if (signal?.mode === 'force') {
+    await forceKillAll(registry, rawDeps.killWorker ?? realKillWorker);
+    overrides?.onShutdown?.('force');
+  } else {
+    overrides?.onShutdown?.('graceful');
+  }
+}
+
+return result;
+```
+
+Remove the line `const mergedPRs = new Set<number>();` that currently exists (line 49) — it's now created conditionally above.
+</action>
+
+<acceptance_criteria>
+- `grep -c "createWorkerRegistry" src/orchestrate.ts` returns at least 1
+- `grep -c "clearShutdownFile" src/orchestrate.ts` returns at least 1
+- `grep -c "shouldShutdown" src/orchestrate.ts` returns at least 1
+- `grep -c "registry.register" src/orchestrate.ts` returns at least 1
+- `grep -c "registry.deregister" src/orchestrate.ts` returns at least 1
+- `grep -c "resumeFromState" src/orchestrate.ts` returns at least 1
+- `grep -c "mergedPRs.add" src/orchestrate.ts` returns at least 1
+- `grep -c "forceKillAll" src/orchestrate.ts` returns at least 1
+- `grep -c "wrapSpawnWorker" src/orchestrate.ts` returns at least 1
+- `grep -c "wrapSpawnDirectWorker" src/orchestrate.ts` returns at least 1
+- `grep -c "onShutdown" src/orchestrate.ts` returns at least 2
+- `pnpm run check` passes
+- `pnpm run build` passes
+</acceptance_criteria>
+
+### Task 4: Add resume detection and shutdown callback to cli.tsx
+
+<read_first>
+- src/cli.tsx (full file — handleStart at lines 41-76, main function)
+- src/shutdown.ts (clearShutdownFile, writeShutdownFile)
+- src/resume.ts (hasExistingState)
+- src/lock.ts (installSignalHandlers — new signature with onShutdown callback)
+</read_first>
+
+<action>
+**A. Add imports at top of cli.tsx:**
+```typescript
+import { clearShutdownFile, writeShutdownFile } from './shutdown.js';
+import { hasExistingState } from './resume.js';
+```
+
+**B. In `handleStart`, update `installSignalHandlers` call:**
+
+Replace:
+```typescript
+installSignalHandlers();
+```
+
+With:
+```typescript
+installSignalHandlers(() => {
+  // SIGINT/SIGTERM triggers graceful shutdown via IPC signal file
+  writeShutdownFile('graceful');
+  // Don't exit — let scheduler see the file and drain gracefully
+});
+```
+
+**C. Clear stale shutdown file after acquiring lock:**
+
+After `acquireLock();` line, add:
+```typescript
+clearShutdownFile();
+```
+
+**D. Add resume detection log before orchestrate call:**
+
+After the `clearShutdownFile()` line, add:
+```typescript
+if (!fresh && hasExistingState()) {
+  process.stdout.write('Detected previous state — will reconcile and resume.\n');
+}
+```
+
+**E. Pass `onShutdown` callback to orchestrate:**
+
+Replace:
+```typescript
+const result = await orchestrate(planPath, (msg) => process.stdout.write(`${msg}\n`));
+```
+
+With:
+```typescript
+const result = await orchestrate(planPath, (msg) => process.stdout.write(`${msg}\n`), {
+  onShutdown: (mode) => {
+    process.stdout.write(`Shutdown (${mode}) complete.\n`);
+    releaseLock();
+    process.exit(0);
+  },
+});
+```
+</action>
+
+<acceptance_criteria>
+- `grep -c "writeShutdownFile" src/cli.tsx` returns at least 1
+- `grep -c "clearShutdownFile" src/cli.tsx` returns at least 1
+- `grep -c "hasExistingState" src/cli.tsx` returns at least 1
+- `grep -c "onShutdown" src/cli.tsx` returns at least 1
+- `grep "installSignalHandlers" src/cli.tsx` shows callback argument (not bare call)
+- `pnpm run check` passes
+- `pnpm run build` passes
+</acceptance_criteria>
+
+## Verification
+
+```bash
+pnpm run check && pnpm run build
+```
+
+## must_haves
+
+- Scheduler checks `deps.shouldShutdown?.()` between issues in processGroup loop
+- On shutdown signal, scheduler writes `step_result: 'interrupted'` and returns `{ shutdown: true }`
+- Signal handlers use re-entrancy guard (`shuttingDown` flag)
+- SIGINT/SIGTERM write graceful shutdown file instead of immediate exit
+- Worker PIDs tracked via registry (register on spawn, deregister on exit event)
+- Both `spawnWorker` and `spawnDirectWorker` wrapped with explicit registry tracking
+- Force shutdown calls `forceKillAll` to SIGTERM all tracked workers
+- Stale shutdown file cleared on every start
+- Resume calls `resumeFromState()` in orchestrate.ts before assignWork
+- `mergedPRs` populated from resume results by mapping branch names to PR numbers from plan data
+- Resume detection logged to user in cli.tsx
+- Lock released on shutdown exit via onShutdown callback

--- a/.planning/phases/07-shutdown-resume/07-03-SUMMARY.md
+++ b/.planning/phases/07-shutdown-resume/07-03-SUMMARY.md
@@ -1,0 +1,106 @@
+---
+phase: 7
+plan: 3
+subsystem: lifecycle
+tags:
+  - shutdown
+  - resume
+  - signal-handling
+  - scheduler
+dependency_graph:
+  requires:
+    - "07-01 (shutdown.ts)"
+    - "07-02 (resume.ts)"
+  provides:
+    - "Scheduler shutdown checkpoint between issues"
+    - "Signal handler re-entrancy guard"
+    - "Worker PID registry for force kill"
+    - "Resume reconciliation on startup"
+    - "CLI shutdown/resume integration"
+  affects:
+    - src/scheduler.ts
+    - src/lock.ts
+    - src/orchestrate.ts
+    - src/cli.tsx
+    - src/types.ts
+tech_stack:
+  patterns:
+    - "IPC via shutdown signal file"
+    - "Worker registry with spawn/exit tracking"
+    - "Immutable status writes with step_result interrupted"
+key_files:
+  modified:
+    - src/types.ts
+    - src/scheduler.ts
+    - src/lock.ts
+    - src/orchestrate.ts
+    - src/cli.tsx
+  created:
+    - src/shutdown.ts
+    - src/resume.ts
+decisions:
+  - "Created Wave 1 files (shutdown.ts, resume.ts) inline as worktree lacked merged Wave 1 commits"
+  - "Added buildGitState helper in orchestrate.ts to construct GitBranchState for resumeFromState"
+  - "Used process.once for signal handlers to match existing pattern (not process.on)"
+metrics:
+  duration: "6m"
+  completed: "2026-05-03T16:28:01Z"
+  tasks_completed: 4
+  tasks_total: 4
+  files_changed: 7
+---
+
+# Phase 7 Plan 3: Core Integration Summary
+
+Wired shutdown coordinator and resume module into scheduler loop, signal handlers, orchestrate entry point, and CLI with worker PID registry tracking.
+
+## Task Results
+
+| Task | Name | Commit | Key Changes |
+|------|------|--------|-------------|
+| 1 | Scheduler shutdown check | 87c4f3e | Shutdown checkpoint in processGroup loop; ShutdownMode/ShutdownSignal types; shouldShutdown on SchedulerDeps; shutdown on GroupResult |
+| 2 | Lock.ts signal handlers | 729c5d3 | onShutdown callback parameter; shuttingDown re-entrancy guard |
+| 3 | Orchestrate.ts wiring | 2c96904 | Worker registry; spawn wrappers; resume detection; forceKillAll; onShutdown callback; buildGitState helper |
+| 4 | CLI resume + shutdown | 7cab183 | writeShutdownFile on SIGINT/SIGTERM; clearShutdownFile on start; resume detection log; onShutdown exit handler |
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 - Blocking] Wave 1 files missing from worktree**
+- **Found during:** Pre-task setup
+- **Issue:** Worktree branch diverged from Wave 1 merge commit (9dccaf8). shutdown.ts, resume.ts, and shutdown types in types.ts did not exist.
+- **Fix:** Created shutdown.ts and resume.ts with identical content from Wave 1 commits; added ShutdownMode/ShutdownSignal types and shouldShutdown to types.ts inline.
+- **Files created:** src/shutdown.ts, src/resume.ts
+- **Files modified:** src/types.ts
+- **Commit:** 87c4f3e (bundled with Task 1)
+
+**2. [Rule 2 - Missing functionality] buildGitState helper**
+- **Found during:** Task 3
+- **Issue:** Plan references resumeFromState which requires a GitBranchState argument, but no helper existed to construct one from git commands.
+- **Fix:** Added buildGitState async function that runs `git branch --list` and `git log` to build the required GitBranchState interface.
+- **Files modified:** src/orchestrate.ts
+- **Commit:** 2c96904
+
+**3. [Rule 1 - Bug] processGroup return type missing shutdown field**
+- **Found during:** Task 1
+- **Issue:** TypeScript error -- processGroup's inline return type did not include `shutdown?: boolean`, causing compilation failure when returning `shutdown: true`.
+- **Fix:** Added `readonly shutdown?: boolean` to the processGroup return type annotation.
+- **Files modified:** src/scheduler.ts
+- **Commit:** 87c4f3e
+
+## Verification
+
+- `tsc --noEmit`: PASS (all 4 tasks verified individually and final build)
+- `biome check`: Could not run (worktree missing node_modules; tsc ran from main repo)
+- All plan acceptance criteria grep checks: PASS
+
+## Known Stubs
+
+None -- all wiring is functional with real implementations.
+
+## Self-Check: PASSED
+
+- All 7 source files verified present on disk
+- All 4 task commits verified in git log (87c4f3e, 729c5d3, 2c96904, 7cab183)
+- No unexpected file deletions

--- a/.planning/phases/07-shutdown-resume/07-04-PLAN.md
+++ b/.planning/phases/07-shutdown-resume/07-04-PLAN.md
@@ -1,0 +1,245 @@
+---
+plan_id: "07-04"
+title: "TUI Shutdown Integration"
+phase: 7
+wave: 3
+depends_on: ["07-01"]
+files_modified:
+  - src/tui/use-keyboard.ts
+  - src/tui/Footer.tsx
+  - src/tui/Dashboard.tsx
+  - src/tui/launch.ts
+  - src/tui/types.ts
+autonomous: true
+requirements_addressed:
+  - "AC: q press scheduler stops assigning new work"
+  - "AC: double q within 2s SIGTERM all workers"
+  - "AC: lock file released on exit"
+---
+
+## Objective
+
+Wire the TUI dashboard to use file-based IPC for shutdown: `q` writes graceful shutdown file, double-`q` within 2 seconds writes force shutdown file. Footer shows shutdown status. Dashboard polls lock file and auto-exits when orchestrator process is gone.
+
+## Tasks
+
+### Task 1: Double-q detection in use-keyboard.ts + shutdown state in types.ts
+
+<read_first>
+- src/tui/use-keyboard.ts (full file -- useInput handler at line 119, stateRef at line 83, existing q handler at line 167-174)
+- src/tui/types.ts (full file -- DashboardState interface)
+- src/shutdown.ts (writeShutdownFile, readShutdownFile, ShutdownSignal)
+- src/lock.ts (readLock, isProcessAlive)
+</read_first>
+
+<action>
+**A. Modify `src/tui/types.ts`** -- add shutdown-related types to DashboardState:
+
+Add a new type:
+```typescript
+export type ShutdownStatus = 'none' | 'graceful' | 'force' | 'exited';
+```
+
+Add to `DashboardState`:
+```typescript
+readonly shutdownStatus: ShutdownStatus;
+```
+
+**B. Modify `src/tui/use-keyboard.ts`**:
+
+1. Add imports:
+```typescript
+import { readShutdownFile, writeShutdownFile } from '../shutdown.js';
+import { isProcessAlive, readLock } from '../lock.js';
+import type { ShutdownStatus } from './types.js';
+```
+
+2. Add `shutdownStatus` state and `lastQPressRef`:
+```typescript
+const [shutdownStatus, setShutdownStatus] = useState<ShutdownStatus>(
+  initialState?.shutdownStatus ?? 'none'
+);
+const lastQPressRef = useRef<number>(0);
+const DOUBLE_Q_THRESHOLD_MS = 2000;
+```
+
+3. Add lock file polling via `useEffect` for auto-exit. Poll every 1000ms:
+```typescript
+useEffect(() => {
+  if (shutdownStatus === 'none') return;
+  // Once shutdown requested, poll lock file to detect orchestrator exit
+  const timer = setInterval(() => {
+    const pid = readLock(baseDir);
+    if (pid === null || !isProcessAlive(pid)) {
+      setShutdownStatus('exited');
+      clearInterval(timer);
+      // Auto-exit dashboard after short delay for user to see status
+      setTimeout(() => {
+        if (onQuit) {
+          onQuit();
+        } else {
+          exit();
+        }
+      }, 1500);
+    }
+    // Also re-read shutdown file in case mode upgraded from graceful to force
+    const signal = readShutdownFile(baseDir);
+    if (signal?.mode === 'force' && shutdownStatus === 'graceful') {
+      setShutdownStatus('force');
+    }
+  }, 1000);
+  return () => clearInterval(timer);
+}, [shutdownStatus, baseDir, exit, onQuit]);
+```
+
+4. Replace the `q` handler (currently lines 167-174) with double-q detection:
+```typescript
+if (input === 'q') {
+  const now = Date.now();
+  const elapsed = now - lastQPressRef.current;
+  lastQPressRef.current = now;
+
+  if (shutdownStatus !== 'none') {
+    // Already in shutdown -- second q upgrades to force
+    if (elapsed < DOUBLE_Q_THRESHOLD_MS) {
+      writeShutdownFile('force', baseDir);
+      setShutdownStatus('force');
+    }
+    return;
+  }
+
+  // First q -- graceful shutdown
+  writeShutdownFile('graceful', baseDir);
+  setShutdownStatus('graceful');
+  return;
+}
+```
+
+5. Add `shutdownStatus` to `stateRef.current` update and to `KeyboardState` return:
+   - Add `shutdownStatus` to the `KeyboardState` interface
+   - Add to `stateRef.current` spread
+   - Add to the return object
+
+6. Update `DashboardState` usage in `stateRef`:
+```typescript
+stateRef.current = { activePanel, selectedGroupIndex, selectedIssueIndex, screenMode, overlay, shutdownStatus };
+```
+</action>
+
+<acceptance_criteria>
+- `grep -c "lastQPressRef" src/tui/use-keyboard.ts` returns at least 1
+- `grep -c "DOUBLE_Q_THRESHOLD_MS" src/tui/use-keyboard.ts` returns at least 1
+- `grep -c "writeShutdownFile" src/tui/use-keyboard.ts` returns at least 2 (graceful + force)
+- `grep -c "readLock" src/tui/use-keyboard.ts` returns at least 1
+- `grep -c "isProcessAlive" src/tui/use-keyboard.ts` returns at least 1
+- `grep -c "ShutdownStatus" src/tui/types.ts` returns at least 1
+- `grep -c "shutdownStatus" src/tui/use-keyboard.ts` returns at least 3
+- `pnpm run check` passes
+</acceptance_criteria>
+
+### Task 2: Footer shutdown status display + Dashboard prop threading
+
+<read_first>
+- src/tui/Footer.tsx (full file -- FooterProps, getHints function, Footer component)
+- src/tui/Dashboard.tsx (full file -- Dashboard component, Footer usage at line 84)
+- src/tui/use-keyboard.ts (shutdownStatus in return value)
+</read_first>
+
+<action>
+**A. Modify `src/tui/Footer.tsx`**:
+
+1. Add `ShutdownStatus` import:
+```typescript
+import type { OverlayMode, ScreenMode, ShutdownStatus } from './types.js';
+```
+
+2. Add `shutdownStatus` to `FooterProps`:
+```typescript
+interface FooterProps {
+  readonly activePanel: number;
+  readonly screenMode: ScreenMode;
+  readonly overlay: OverlayMode;
+  readonly shutdownStatus: ShutdownStatus;
+  readonly activeWorkerCount?: number;
+}
+```
+
+3. Modify `Footer` component: when `shutdownStatus !== 'none'`, render shutdown message INSTEAD of normal hints:
+
+```typescript
+export function Footer({ activePanel, screenMode, overlay, shutdownStatus, activeWorkerCount }: FooterProps): ReactNode {
+  if (shutdownStatus === 'exited') {
+    return (
+      <Box>
+        <Text color="green">Orchestrator exited. Dashboard closing...</Text>
+      </Box>
+    );
+  }
+  if (shutdownStatus === 'force') {
+    return (
+      <Box>
+        <Text color="yellow">{'⚠'} Force killing workers...</Text>
+      </Box>
+    );
+  }
+  if (shutdownStatus === 'graceful') {
+    const workerText = activeWorkerCount !== undefined ? ` ${activeWorkerCount} worker(s)` : '';
+    return (
+      <Box>
+        <Text color="cyan">{'⏳'} Shutting down — waiting for{workerText}... (q again to force kill)</Text>
+      </Box>
+    );
+  }
+
+  // Normal mode -- existing hint logic
+  const hints = getHints(activePanel, screenMode, overlay);
+  // ... rest unchanged
+}
+```
+
+**B. Modify `src/tui/Dashboard.tsx`**:
+
+Pass `shutdownStatus` from `useKeyboard` result down to `Footer`:
+
+```typescript
+const { activePanel, selectedGroupIndex, selectedIssueIndex, screenMode, overlay, error, shutdownStatus } =
+  useKeyboard({ groups, baseDir, initialState, onTakeover, onQuit });
+```
+
+Update Footer usage:
+```typescript
+<Footer activePanel={activePanel} screenMode={screenMode} overlay={overlay} shutdownStatus={shutdownStatus} />
+```
+
+**C. Modify `src/tui/launch.ts`**:
+
+Add `shutdownStatus: 'none'` as default when initializing `savedState`. The existing `savedState` needs to include `shutdownStatus`. Since `DashboardState` now includes it, make sure the `savedState` in the `onTakeover` callback captures it. No other changes needed -- the `shutdownStatus` resets naturally when the dashboard re-renders.
+</action>
+
+<acceptance_criteria>
+- `grep -c "shutdownStatus" src/tui/Footer.tsx` returns at least 3
+- `grep -c "Force killing" src/tui/Footer.tsx` returns 1
+- `grep -c "Shutting down" src/tui/Footer.tsx` returns 1
+- `grep -c "force kill" src/tui/Footer.tsx` returns 1
+- `grep -c "shutdownStatus" src/tui/Dashboard.tsx` returns at least 2
+- `pnpm run check` passes
+- `pnpm run build` passes
+</acceptance_criteria>
+
+## Verification
+
+```bash
+pnpm run check && pnpm run build
+```
+
+## must_haves
+
+- Double-q detection: first q = graceful, second q within 2s = force
+- Dashboard writes `.orchestrator/shutdown` file (does not directly exit)
+- Footer shows graceful message: "Shutting down -- waiting for N worker(s)... (q again to force kill)"
+- Footer shows force message: "Force killing workers..."
+- Footer shows exited message: "Orchestrator exited. Dashboard closing..."
+- Dashboard polls lock file after shutdown requested
+- Dashboard auto-exits when lock file gone (orchestrator dead)
+- Normal footer hints shown when shutdownStatus is 'none'
+- ShutdownStatus type exported from tui/types.ts

--- a/.planning/phases/07-shutdown-resume/07-04-SUMMARY.md
+++ b/.planning/phases/07-shutdown-resume/07-04-SUMMARY.md
@@ -1,0 +1,36 @@
+---
+plan_id: "07-04"
+title: "TUI Shutdown Integration"
+status: complete
+started: 2026-05-04T00:30:00Z
+completed: 2026-05-04T00:45:00Z
+---
+
+## Summary
+
+Wired TUI dashboard to use file-based IPC for shutdown signaling. Single `q` writes graceful shutdown file, double-`q` within 2 seconds writes force shutdown file. Footer displays shutdown status with color-coded messages. Dashboard polls lock file after shutdown requested and auto-exits when orchestrator process terminates.
+
+## Tasks Completed
+
+| # | Task | Status |
+|---|------|--------|
+| 1 | Double-q detection in use-keyboard.ts + shutdown state in types.ts | ✓ |
+| 2 | Footer shutdown status display + Dashboard prop threading | ✓ |
+
+## Key Files
+
+### Modified
+- `src/tui/types.ts` — Added `ShutdownStatus` type and `shutdownStatus` to `DashboardState`
+- `src/tui/use-keyboard.ts` — Double-q detection with 2s threshold, lock file polling via `useEffect`, graceful→force upgrade path, auto-exit on orchestrator termination
+- `src/tui/Footer.tsx` — Shutdown status display with graceful/force/exited messages and yellow/red color coding
+- `src/tui/Dashboard.tsx` — Threading `shutdownStatus` prop from `useKeyboard` to `Footer`
+
+## Self-Check: PASSED
+
+- `pnpm run check` — passes
+- `pnpm run build` — passes
+- All acceptance criteria met
+
+## Deviations
+
+None.

--- a/.planning/phases/07-shutdown-resume/07-05-PLAN.md
+++ b/.planning/phases/07-shutdown-resume/07-05-PLAN.md
@@ -1,0 +1,200 @@
+---
+plan_id: "07-05"
+title: "Tests for Shutdown + Resume"
+phase: 7
+wave: 4
+depends_on: ["07-01", "07-02", "07-03", "07-04"]
+files_modified:
+  - src/shutdown.test.ts
+  - src/resume.test.ts
+  - src/scheduler.test.ts
+  - src/lock.test.ts
+autonomous: true
+requirements_addressed:
+  - "AC: tests verify shutdown state writing"
+  - "AC: tests verify resume logic with various git states"
+---
+
+## Objective
+
+Create comprehensive tests for the shutdown coordinator, resume module, scheduler shutdown checkpoint, and enhanced signal handlers. These tests verify all acceptance criteria from issue #18 that are testable in unit/integration form.
+
+## Tasks
+
+### Task 1: Tests for src/shutdown.ts
+
+<read_first>
+- src/shutdown.ts (all exports: writeShutdownFile, readShutdownFile, clearShutdownFile, createWorkerRegistry, forceKillAll, getShutdownPath)
+- src/lock.test.ts (test pattern: tmpDir setup/teardown, vitest imports)
+</read_first>
+
+<action>
+Create `src/shutdown.test.ts` with these test groups:
+
+```typescript
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  clearShutdownFile,
+  createWorkerRegistry,
+  forceKillAll,
+  getShutdownPath,
+  readShutdownFile,
+  writeShutdownFile,
+} from './shutdown.js';
+```
+
+Setup: `tmpDir` with `.orchestrator` directory (same pattern as lock.test.ts).
+
+**describe('getShutdownPath'):**
+- returns path ending in `.orchestrator/shutdown`
+- uses baseDir when provided
+
+**describe('writeShutdownFile'):**
+- creates file with valid JSON containing mode and requested_at
+- creates directory if missing
+- overwrites existing file (graceful -> force upgrade)
+- mode 'graceful' writes `{"mode":"graceful",...}`
+- mode 'force' writes `{"mode":"force",...}`
+
+**describe('readShutdownFile'):**
+- returns null when file missing
+- returns ShutdownSignal for valid file
+- returns null for malformed JSON
+- returns null for invalid mode value (e.g. `{"mode":"unknown"}`)
+
+**describe('clearShutdownFile'):**
+- removes existing file
+- no-ops when file missing (no throw)
+
+**describe('createWorkerRegistry'):**
+- register adds PID, getActivePids returns it
+- deregister removes PID
+- deregister no-ops for unknown PID
+- getActivePids returns empty array initially
+- multiple register/deregister cycles work correctly
+
+**describe('forceKillAll'):**
+- calls killWorker for each active PID
+- handles empty registry (no calls)
+- handles killWorker rejection gracefully (Promise.allSettled)
+
+For `forceKillAll` tests, mock `killWorker`:
+```typescript
+const mockKill = vi.fn().mockResolvedValue(undefined);
+```
+</action>
+
+<acceptance_criteria>
+- File `src/shutdown.test.ts` exists
+- `grep -c "describe(" src/shutdown.test.ts` returns at least 6
+- `grep -c "it(" src/shutdown.test.ts` returns at least 14
+- `pnpm run test -- --run src/shutdown.test.ts` passes
+</acceptance_criteria>
+
+### Task 2: Tests for src/resume.ts and scheduler shutdown + lock handler
+
+<read_first>
+- src/resume.ts (all exports: hasExistingState, detectMergedPRs, resetToCheckpoint, resumeFromState)
+- src/scheduler.test.ts (existing test pattern, mock SchedulerDeps setup)
+- src/lock.test.ts (existing tests to extend)
+- src/types.ts (GroupStatus, GroupStep, GitBranchState)
+</read_first>
+
+<action>
+**A. Create `src/resume.test.ts`:**
+
+Setup: tmpDir with `.orchestrator/status` directory.
+
+**describe('hasExistingState'):**
+- returns false when status dir missing
+- returns false when status dir empty
+- returns true when status dir has .json files
+- returns false when status dir has only non-json files
+
+**describe('resetToCheckpoint'):**
+Test each branch of the decision tree:
+- `idle + pass + no remaining` -> resets to idle with empty step_result (restart from self-review)
+- `reviewing` -> resets to idle (died mid-phase)
+- `pr-creating` -> resets to idle (died mid-phase)
+- `pr-reviewing` -> resets to idle (died mid-phase)
+- `awaiting-merge + branch merged` -> marks fully done (step_result: 'pass', issues_remaining: [])
+- `awaiting-merge + branch NOT merged` -> returns unchanged
+- `coding` -> resets to idle (died mid-issue, current_issue preserved for retry)
+- `cloning` -> resets to idle
+- `verifying` -> resets to idle
+- `idle + interrupted` -> resets step_result to '' (previously shut down)
+- unknown/default -> returns unchanged
+
+**describe('detectMergedPRs'):**
+- returns merged branches when gh reports merged PRs
+- returns empty array for no awaiting-merge statuses
+- handles gh command failure gracefully (returns empty, logs warning)
+- skips non-awaiting-merge statuses
+
+Mock `execCommand` to return JSON:
+```typescript
+const mockExec = vi.fn().mockResolvedValue({
+  exitCode: 0,
+  stdout: JSON.stringify([{ number: 42, state: 'MERGED' }]),
+  stderr: '',
+});
+```
+
+**B. Extend `src/scheduler.test.ts`:**
+
+Add a new `describe('processGroup shutdown')` block. Use the existing mock deps pattern from the file. Add tests:
+
+- When `shouldShutdown` returns graceful signal, loop stops before next issue
+- Status written with `step_result: 'interrupted'` on shutdown
+- Current issue completes before shutdown check (no mid-step interruption)
+- When `shouldShutdown` is undefined (backward compat), loop runs normally
+
+Key: create mock deps with `shouldShutdown` that returns `{ mode: 'graceful', requested_at: '...' }` after first issue completes. Verify second issue is NOT processed.
+
+**C. Extend `src/lock.test.ts`:**
+
+Add `describe('installSignalHandlers with callback')`:
+- Calls onShutdown callback instead of process.exit when provided
+- Re-entrancy guard prevents double invocation
+
+Note: Testing signal handlers is tricky. Use approach: call the handler function directly if exposed, or verify behavior indirectly by checking that the function accepts the callback parameter and compiles correctly. The most reliable test is to verify `installSignalHandlers` accepts a callback by calling it with one and verifying no error.
+</action>
+
+<acceptance_criteria>
+- File `src/resume.test.ts` exists
+- `grep -c "describe(" src/resume.test.ts` returns at least 3
+- `grep -c "it(" src/resume.test.ts` returns at least 10
+- `grep -c "resetToCheckpoint" src/resume.test.ts` returns at least 8
+- `grep -c "shouldShutdown" src/scheduler.test.ts` returns at least 2
+- `grep -c "interrupted" src/scheduler.test.ts` returns at least 1
+- `pnpm run test -- --run src/shutdown.test.ts src/resume.test.ts` passes
+- `pnpm run test -- --run src/scheduler.test.ts` passes
+- `pnpm run test -- --run src/lock.test.ts` passes
+</acceptance_criteria>
+
+## Verification
+
+```bash
+pnpm run test -- --run src/shutdown.test.ts src/resume.test.ts src/scheduler.test.ts src/lock.test.ts
+```
+
+Full suite:
+```bash
+pnpm run test
+```
+
+## must_haves
+
+- shutdown.test.ts covers signal file CRUD (write, read, clear)
+- shutdown.test.ts covers WorkerRegistry (register, deregister, getActivePids)
+- shutdown.test.ts covers forceKillAll with mocked killWorker
+- resume.test.ts covers hasExistingState with various directory states
+- resume.test.ts covers ALL branches of resetToCheckpoint decision tree
+- resume.test.ts covers detectMergedPRs with mocked gh command
+- scheduler.test.ts verifies shutdown checkpoint stops issue loop
+- scheduler.test.ts verifies step_result: 'interrupted' written on shutdown
+- lock.test.ts verifies callback-based signal handler signature
+- All tests pass: `pnpm run test` exits 0

--- a/.planning/phases/07-shutdown-resume/07-05-SUMMARY.md
+++ b/.planning/phases/07-shutdown-resume/07-05-SUMMARY.md
@@ -1,0 +1,109 @@
+---
+phase: 7
+plan: 5
+subsystem: testing
+tags:
+  - shutdown
+  - resume
+  - vitest
+  - signal-handling
+dependency_graph:
+  requires:
+    - 07-01 (shutdown.ts)
+    - 07-02 (resume.ts)
+    - 07-03 (scheduler/lock/orchestrate wiring)
+    - 07-04 (TUI integration)
+  provides:
+    - test coverage for shutdown coordinator
+    - test coverage for resume module
+    - test coverage for scheduler shutdown checkpoint
+    - test coverage for lock signal handler callback
+  affects:
+    - src/shutdown.test.ts
+    - src/resume.test.ts
+    - src/scheduler.test.ts
+    - src/lock.test.ts
+tech_stack:
+  added: []
+  patterns:
+    - vitest describe/it/vi.fn patterns
+    - tmpDir setup/teardown for filesystem tests
+    - mock dependency injection for async operations
+key_files:
+  created:
+    - src/shutdown.test.ts
+    - src/resume.test.ts
+  modified:
+    - src/scheduler.test.ts
+    - src/lock.test.ts
+decisions:
+  - "Used same tmpDir + beforeEach/afterEach pattern as existing lock.test.ts for consistency"
+  - "Tested installSignalHandlers via signature acceptance rather than signal emission (safer, avoids test process termination)"
+  - "Used vi.fn() mock for killWorker in forceKillAll tests to verify Promise.allSettled behavior"
+metrics:
+  duration: ~8min
+  completed: 2026-05-03
+---
+
+# Phase 7 Plan 5: Tests for Shutdown + Resume Summary
+
+Comprehensive vitest test suite for shutdown coordinator, resume module, scheduler shutdown checkpoint, and lock signal handler callback
+
+## Task Results
+
+| Task | Name | Commit | Files |
+|------|------|--------|-------|
+| 1 | Tests for src/shutdown.ts | 0950875 | src/shutdown.test.ts |
+| 2 | Tests for resume, scheduler shutdown, lock handlers | c9ec11d | src/resume.test.ts, src/scheduler.test.ts, src/lock.test.ts |
+
+## What Was Built
+
+### shutdown.test.ts (6 describe blocks, 21 test cases)
+
+- **getShutdownPath**: Path construction with/without baseDir
+- **writeShutdownFile**: File creation, directory creation, overwrite (graceful->force), mode validation
+- **readShutdownFile**: Missing file, valid file, malformed JSON, invalid mode
+- **clearShutdownFile**: Removal, no-op on missing
+- **createWorkerRegistry**: Register/deregister/getActivePids lifecycle
+- **forceKillAll**: Calls killWorker per PID, empty registry, rejection handling via Promise.allSettled
+
+### resume.test.ts (3 describe blocks, 19 test cases)
+
+- **hasExistingState**: Missing dir, empty dir, JSON files present, non-JSON only
+- **resetToCheckpoint**: All 10 branches of the decision tree tested:
+  - idle+pass+no-remaining -> restart from self-review
+  - reviewing/pr-creating/pr-reviewing -> reset to idle
+  - awaiting-merge+merged -> fully done
+  - awaiting-merge+not-merged -> unchanged
+  - coding/cloning/verifying -> idle (current_issue preserved)
+  - idle+interrupted -> clear step_result
+  - default -> unchanged
+- **detectMergedPRs**: Merged branches, no awaiting-merge, gh failure, skip non-awaiting
+
+### scheduler.test.ts extensions (4 test cases)
+
+- shouldShutdown returns graceful -> loop stops before next issue
+- Status written with step_result: 'interrupted' on shutdown
+- Current issue completes before shutdown check (no mid-step interruption)
+- shouldShutdown undefined -> loop runs normally (backward compat)
+
+### lock.test.ts extensions (2 test cases)
+
+- installSignalHandlers accepts onShutdown callback without error
+- Function signature accepts optional parameters
+
+## Acceptance Criteria Verification
+
+- shutdown.test.ts: 6 describe blocks (requires >= 6), 21 it blocks (requires >= 14)
+- resume.test.ts: 3 describe blocks (requires >= 3), 19 it blocks (requires >= 10)
+- resume.test.ts: 13 resetToCheckpoint references (requires >= 8)
+- scheduler.test.ts: 9 shouldShutdown references (requires >= 2)
+- scheduler.test.ts: 4 interrupted references (requires >= 1)
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Known Issues
+
+**Test execution could not be verified in worktree**: The `pnpm install` command was persistently blocked by the permission system, preventing node_modules installation in the worktree. Tests follow established patterns from lock.test.ts and scheduler.test.ts and should pass when dependencies are available. Verification should be run after merge: `pnpm run test`.

--- a/.planning/phases/07-shutdown-resume/07-CONTEXT.md
+++ b/.planning/phases/07-shutdown-resume/07-CONTEXT.md
@@ -1,0 +1,100 @@
+# Phase 7 Context: Shutdown + Resume
+
+**Date:** 2026-05-03
+**Issue:** #18
+**Branch:** feat/shutdown-resume
+**Depends on:** PR 4 (Scheduler), PR 5 (TUI Dashboard), PR 6 (Resilience)
+
+## Domain
+
+Graceful lifecycle management — stop orchestration cleanly via IPC, resume from persisted state with git cross-referencing.
+
+## Assumptions Audit Findings
+
+Before discussion, we identified critical mismatches between the issue's acceptance criteria and the actual codebase:
+
+1. **`dashboard` and `start` are separate processes** — issue assumes `q` press controls orchestration, but they're independent CLI commands with no communication channel. Resolved by choosing IPC mode (signal file).
+2. **No cancellation mechanism in `assignWork()`** — uses `Promise.allSettled()` with no way to signal "stop accepting new work" mid-flight. Needs shutdown check points.
+3. **Resume partially exists** — `processGroup()` already reads `issues_remaining` from disk (scheduler.ts:241-246), but `orchestrate()` creates fresh `mergedPRs = new Set()` and doesn't call `reconcile()`. Group-level phase resume doesn't exist.
+4. **Signal handlers only release lock** — `installSignalHandlers()` in lock.ts calls `releaseLock()` then `process.exit(0)`. No state flush, no worker drain.
+
+## Decisions
+
+### IPC: Signal File + Polling
+- Dashboard writes `.orchestrator/shutdown` file on `q` press
+- File content: `{"mode": "graceful" | "force", "requested_at": "ISO timestamp"}`
+- Orchestrator polls for this file between steps
+- Single `q` → graceful mode. Double `q` within 2s → force mode
+- Dashboard reads lock file to detect when orchestrator has exited, then auto-exits itself
+
+### Shutdown Check Points: Between Issues Only
+- Orchestrator checks shutdown signal after each `processIssue()` completes, before starting next issue
+- Current issue always runs to completion (no mid-step interruption)
+- On graceful shutdown: write status with `step_result: "interrupted"` for remaining issues, release lock, exit
+- On force shutdown: SIGTERM all worker processes, best-effort state flush, release lock, exit
+- No check points between group phases (self-review, PR creation, etc.) — keeps implementation simple
+
+### Resume: Reset to Last Safe Checkpoint
+- On `orchestrator start` with existing status files (no `--fresh`): treat as resume
+- Call `reconcile()` before `assignWork()` to sync status with git state
+- Detect already-merged PRs by checking git state / GitHub
+- Resume decision tree:
+  - `step == 'idle' && step_result == 'pass'` → all issues done → restart from self-review
+  - `step in ['reviewing', 'pr-creating', 'pr-reviewing']` → died mid-phase → reset to idle, restart from self-review
+  - `step == 'awaiting-merge'` → check if PR merged via reconcile → if merged: mark done, if not: resume merge wait
+  - `step in ['coding', 'cloning', 'verifying']` → died mid-issue → restart current issue (already in `issues_remaining`)
+
+### TUI Shutdown Feedback: Footer Status Line
+- Replace footer hint text with shutdown status
+- Graceful: `⏳ Shutting down — waiting for N worker(s)... (q again to force kill)`
+- Force: `⚠ Force killing workers...`
+- Dashboard polls lock file, auto-exits when orchestrator process gone
+
+### GroupStep / Status Enhancements
+- Add `step_result: "interrupted"` as documented shutdown state
+- Existing `GroupStep` type sufficient — no new steps needed
+- Status written atomically (already uses tmp+rename pattern)
+
+### --fresh Flag
+- Already implemented in `clearRuntimeState()` — deletes status/, context/, logs/, worktrees/
+- No changes needed
+
+### Signal Handlers
+- Enhance `installSignalHandlers()` to flush state before exit
+- SIGINT/SIGTERM: trigger graceful shutdown (write shutdown file for self, same code path)
+- Direct Ctrl+C to orchestrator process (no dashboard): same graceful drain logic
+
+## Code Context
+
+### Files to Modify
+- `src/cli.tsx` — add resume detection in `handleStart`, call `reconcile()` before orchestrate
+- `src/lock.ts` — enhance signal handlers to trigger shutdown coordinator
+- `src/scheduler.ts` — add shutdown check in `processGroup` loop, return `interrupted` result
+- `src/orchestrate.ts` — pass shutdown signal through, handle interrupted results
+- `src/tui/use-keyboard.ts` — change `q` to write shutdown file instead of exit
+- `src/tui/Dashboard.tsx` — footer shutdown status, lock file polling for auto-exit
+- `src/tui/launch.ts` — integrate shutdown state into dashboard loop
+
+### New Files
+- `src/shutdown.ts` — shutdown coordinator: read/write/poll shutdown file, force kill logic
+- `src/resume.ts` — resume logic: reconcile + merged PR detection + checkpoint reset
+
+### Existing Patterns to Follow
+- Atomic file writes via tmp+rename (status-manager.ts:72-74)
+- `SchedulerDeps` injection for testability
+- Immutable status updates via spread (scheduler.ts throughout)
+- `safeWriteStatus()` wrapper for error-safe I/O (scheduler.ts:108-115)
+
+## Canonical Refs
+- `docs/decisions/001-design-decisions.md` — 26 locked design decisions including "no daemon mode"
+- `src/types.ts` — GroupStatus, GroupStep, SchedulerDeps interfaces
+- `src/status-manager.ts` — reconcile() function, atomic write pattern
+- `src/lock.ts` — current signal handler implementation
+- `src/scheduler.ts` — processGroup loop, processIssue, assignWork
+- `src/tui/use-keyboard.ts` — current q-press handling
+
+## Out of Scope
+- Detach/background mode (rejected in ADR 001)
+- Daemon process management
+- Mid-step interruption (coding step can't be cancelled gracefully)
+- AbortSignal-based cooperative cancellation (too invasive for v1)

--- a/.planning/phases/07-shutdown-resume/07-RESEARCH.md
+++ b/.planning/phases/07-shutdown-resume/07-RESEARCH.md
@@ -1,0 +1,568 @@
+# Phase 7: Shutdown + Resume - Research
+
+**Researched:** 2026-05-03
+**Domain:** Process lifecycle management, file-based IPC, cooperative shutdown, state reconciliation
+**Confidence:** HIGH
+
+## Summary
+
+This phase adds graceful shutdown and auto-resume to the orchestrator. The core mechanism is file-based IPC: the dashboard writes a `.orchestrator/shutdown` signal file, and the orchestrator process polls for it between `processIssue()` calls. Two shutdown modes exist: graceful (finish current issue, flush state, exit) and force (SIGTERM all workers, best-effort flush, exit). Resume detects existing status files on startup and reconciles them against git/GitHub state before continuing.
+
+The codebase already has strong foundations: atomic file writes via tmp+rename in `status-manager.ts`, a polling pattern in `use-status-poller.ts` and `merge-detector.ts`, `killWorker()` with SIGTERM-then-SIGKILL escalation in `worker-manager.ts`, and dependency injection via `SchedulerDeps` for testability. The primary engineering challenge is threading shutdown awareness through the `processGroup` loop in `scheduler.ts` without breaking the existing `Promise.allSettled` concurrency model.
+
+**Primary recommendation:** Implement shutdown as a pure-function coordinator module (`src/shutdown.ts`) that reads/writes/polls the signal file, and a resume module (`src/resume.ts`) that wraps reconcile + merged-PR detection + checkpoint reset. Thread a `shouldShutdown()` callback through `SchedulerDeps` so the scheduler can check between issues without direct file I/O coupling.
+
+<user_constraints>
+## User Constraints (from CONTEXT.md)
+
+### Locked Decisions
+- IPC: Signal file + polling (`.orchestrator/shutdown`), file content: `{"mode": "graceful" | "force", "requested_at": "ISO timestamp"}`
+- Dashboard writes shutdown file on `q` press; single `q` = graceful, double `q` within 2s = force
+- Orchestrator polls for shutdown file between steps (after each `processIssue()`)
+- Current issue always runs to completion (no mid-step interruption)
+- Graceful: write status with `step_result: "interrupted"` for remaining issues, release lock, exit
+- Force: SIGTERM all workers, best-effort state flush, release lock, exit
+- No check points between group phases (self-review, PR creation, etc.)
+- Resume: on `orchestrator start` with existing status files (no `--fresh`), treat as resume
+- Call `reconcile()` before `assignWork()` to sync status with git state
+- Detect already-merged PRs by checking git state / GitHub
+- Resume decision tree defined in CONTEXT.md (idle+pass -> restart from self-review, mid-phase -> reset to idle, awaiting-merge -> check PR, mid-issue -> restart current issue)
+- TUI: Footer status line for shutdown feedback
+- Dashboard polls lock file, auto-exits when orchestrator process gone
+- Add `step_result: "interrupted"` as documented shutdown state
+- Enhance `installSignalHandlers()` to flush state before exit (SIGINT/SIGTERM trigger graceful shutdown)
+- `--fresh` flag: no changes needed (already implemented)
+
+### Claude's Discretion
+- Internal implementation details of shutdown coordinator
+- Polling interval for shutdown file
+- How to thread shutdown signal through scheduler
+- Resume helper internals
+- Test strategy details
+
+### Deferred Ideas (OUT OF SCOPE)
+- Detach/background mode (rejected in ADR 001)
+- Daemon process management
+- Mid-step interruption (coding step cannot be cancelled gracefully)
+- AbortSignal-based cooperative cancellation (too invasive for v1)
+</user_constraints>
+
+## Architectural Responsibility Map
+
+| Capability | Primary Tier | Secondary Tier | Rationale |
+|------------|-------------|----------------|-----------|
+| Shutdown signal file I/O | Shutdown coordinator (`src/shutdown.ts`) | -- | Centralized read/write/poll of `.orchestrator/shutdown` |
+| Graceful drain (finish current issue) | Scheduler (`src/scheduler.ts`) | -- | `processGroup` loop owns the issue iteration; shutdown check goes between iterations |
+| Force kill workers | Shutdown coordinator | Worker manager | Coordinator decides to kill; delegates to existing `killWorker()` |
+| State flush on shutdown | Scheduler | Status manager | Scheduler writes `step_result: "interrupted"` via existing `safeWriteStatus` |
+| Resume detection | CLI (`src/cli.tsx`) | -- | `handleStart` detects existing status files before calling orchestrate |
+| Reconciliation + PR detection | Resume module (`src/resume.ts`) | Status manager | New module wraps `reconcile()` + `gh pr view` checks |
+| Dashboard shutdown feedback | TUI (Footer, use-keyboard) | -- | Footer shows shutdown status; `q` press writes signal file |
+| Lock file polling (auto-exit) | TUI (Dashboard/launch) | Lock module | Dashboard polls `readLock()` to detect orchestrator exit |
+| Signal handler enhancement | Lock module (`src/lock.ts`) | Shutdown coordinator | Signal handlers trigger shutdown coordinator instead of raw exit |
+
+## Standard Stack
+
+### Core
+| Library | Version | Purpose | Why Standard |
+|---------|---------|---------|--------------|
+| node:fs | built-in | Signal file I/O, atomic writes | Already used throughout codebase for status/lock files [VERIFIED: codebase] |
+| node:child_process | built-in | Worker process management | Already used in worker-manager.ts [VERIFIED: codebase] |
+| ink | ^7.0.0 | TUI framework (useInput, useApp) | Already the project's TUI framework [VERIFIED: package.json] |
+| react | ^19.0.0 | Component model for TUI | Already the project's UI layer [VERIFIED: package.json] |
+| vitest | ^3.0.0 | Test framework | Already configured in vitest.config.ts [VERIFIED: codebase] |
+
+### Supporting
+No new dependencies needed. This phase uses only Node.js built-ins and existing project dependencies.
+
+## Architecture Patterns
+
+### System Architecture Diagram
+
+```
+Dashboard Process                    Orchestrator Process
+==================                   ====================
+
+[q press] ──────────────────────────────────────────────────┐
+     │                                                       │
+     v                                                       │
+writeShutdownFile()                                          │
+  ".orchestrator/shutdown"                                   │
+  {"mode":"graceful","requested_at":"..."}                   │
+     │                                                       │
+     │         ┌─────────────────────────────────────────────┘
+     │         │
+     │         v
+     │    pollShutdownFile() ◄── called between processIssue() calls
+     │         │
+     │         ├── graceful ──► finish current issue
+     │         │                  │
+     │         │                  v
+     │         │              write "interrupted" for remaining issues
+     │         │                  │
+     │         │                  v
+     │         │              releaseLock() + process.exit()
+     │         │
+     │         └── force ────► SIGTERM all workers
+     │                           │
+     │                           v
+     │                        best-effort state flush
+     │                           │
+     │                           v
+     │                        releaseLock() + process.exit()
+     │
+     v
+[poll lockFile] ──► lock gone? ──► auto-exit dashboard
+
+
+Resume Flow (orchestrator start):
+=================================
+
+handleStart()
+     │
+     ├── --fresh? ──► clearRuntimeState() ──► normal start
+     │
+     └── existing status files? ──► resume path
+              │
+              v
+         reconcile(gitState)         ← fix stale statuses
+              │
+              v
+         detectMergedPRs()           ← gh pr view for awaiting-merge groups
+              │
+              v
+         resetCheckpoints()          ← apply resume decision tree
+              │
+              v
+         assignWork(plan, mergedPRs) ← normal scheduler with updated state
+```
+
+### Recommended Project Structure
+```
+src/
+├── shutdown.ts          # NEW: shutdown coordinator (read/write/poll signal file)
+├── resume.ts            # NEW: resume logic (reconcile + PR detection + checkpoint reset)
+├── scheduler.ts         # MODIFY: add shouldShutdown check in processGroup loop
+├── orchestrate.ts       # MODIFY: pass shutdown signal, handle interrupted results
+├── lock.ts              # MODIFY: enhance signal handlers to trigger shutdown
+├── cli.tsx              # MODIFY: add resume detection in handleStart
+├── types.ts             # MODIFY: add ShutdownMode type, extend SchedulerDeps
+├── tui/
+│   ├── use-keyboard.ts  # MODIFY: q writes shutdown file, double-q detection
+│   ├── Dashboard.tsx     # MODIFY: pass shutdown state to Footer
+│   ├── Footer.tsx        # MODIFY: conditional shutdown status display
+│   └── launch.ts         # MODIFY: lock file polling for auto-exit
+```
+
+### Pattern 1: Shutdown Coordinator Module
+**What:** A stateless module that encapsulates all shutdown signal file operations.
+**When to use:** Any component that needs to read, write, or poll the shutdown signal.
+
+```typescript
+// src/shutdown.ts
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+export type ShutdownMode = 'graceful' | 'force';
+
+export interface ShutdownSignal {
+  readonly mode: ShutdownMode;
+  readonly requested_at: string;
+}
+
+export function getShutdownPath(baseDir?: string): string {
+  return path.resolve(baseDir ?? '.', '.orchestrator/shutdown');
+}
+
+export function writeShutdownFile(mode: ShutdownMode, baseDir?: string): void {
+  const filePath = getShutdownPath(baseDir);
+  const dir = path.dirname(filePath);
+  fs.mkdirSync(dir, { recursive: true });
+  const signal: ShutdownSignal = {
+    mode,
+    requested_at: new Date().toISOString(),
+  };
+  // Atomic write via tmp+rename (same pattern as status-manager.ts:72-74)
+  const tmpPath = `${filePath}.tmp`;
+  fs.writeFileSync(tmpPath, JSON.stringify(signal, null, '\t'));
+  fs.renameSync(tmpPath, filePath);
+}
+
+export function readShutdownFile(baseDir?: string): ShutdownSignal | null {
+  const filePath = getShutdownPath(baseDir);
+  try {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const parsed = JSON.parse(content) as ShutdownSignal;
+    if (parsed.mode === 'graceful' || parsed.mode === 'force') {
+      return parsed;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function clearShutdownFile(baseDir?: string): void {
+  try {
+    fs.unlinkSync(getShutdownPath(baseDir));
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
+}
+```
+[VERIFIED: codebase patterns from status-manager.ts and lock.ts]
+
+### Pattern 2: Threading Shutdown Through SchedulerDeps
+**What:** Add a `shouldShutdown` callback to `SchedulerDeps` so the scheduler checks for shutdown without direct file I/O.
+**When to use:** Between `processIssue()` calls in the `processGroup` loop.
+
+```typescript
+// Addition to SchedulerDeps interface in types.ts
+export interface SchedulerDeps {
+  // ... existing fields ...
+  readonly shouldShutdown?: () => ShutdownSignal | null;
+}
+
+// In scheduler.ts processGroup loop:
+for (const issueNumber of remaining) {
+  // Check for shutdown BEFORE starting next issue
+  const shutdownSignal = deps.shouldShutdown?.();
+  if (shutdownSignal) {
+    // Write interrupted status for remaining issues
+    safeWriteStatus(deps, slug, {
+      ...freshStatus(slug, group, deps, now),
+      current_issue: null,
+      step: 'idle',
+      step_result: 'interrupted',
+      last_updated: now(),
+    });
+    return { completed: false, error: `shutdown: ${shutdownSignal.mode}` };
+  }
+
+  const result = await processIssue(group, issueNumber, slug, config, deps, now);
+  if (!result.success) {
+    return { completed: false, failedIssue: issueNumber, error: result.error };
+  }
+}
+```
+[VERIFIED: codebase pattern from scheduler.ts:248-254 and types.ts SchedulerDeps]
+
+### Pattern 3: Double-Keypress Detection in React/Ink
+**What:** Track last `q` press timestamp with `useRef`, compare on second press.
+**When to use:** In `use-keyboard.ts` for graceful vs force shutdown selection.
+
+```typescript
+// In use-keyboard.ts
+const lastQPressRef = useRef<number>(0);
+const DOUBLE_Q_THRESHOLD_MS = 2000;
+
+// Inside useInput callback:
+if (input === 'q') {
+  const now = Date.now();
+  const elapsed = now - lastQPressRef.current;
+  lastQPressRef.current = now;
+
+  if (elapsed < DOUBLE_Q_THRESHOLD_MS) {
+    // Double q -> force shutdown
+    writeShutdownFile('force', baseDir);
+  } else {
+    // Single q -> graceful shutdown
+    writeShutdownFile('graceful', baseDir);
+  }
+  return;
+}
+```
+[VERIFIED: useRef pattern already used in use-keyboard.ts:83 (stateRef), Ink useInput API from Context7]
+
+### Pattern 4: Lock File Polling for Dashboard Auto-Exit
+**What:** Dashboard polls the lock file to detect when the orchestrator process has exited.
+**When to use:** After shutdown signal is written, dashboard waits for orchestrator to finish.
+
+```typescript
+// In Dashboard.tsx or a new hook
+const [shutdownState, setShutdownState] = useState<ShutdownSignal | null>(null);
+
+useEffect(() => {
+  const timer = setInterval(() => {
+    // Check if shutdown was requested
+    const signal = readShutdownFile(baseDir);
+    setShutdownState(signal);
+
+    // Check if orchestrator is gone
+    if (signal) {
+      const pid = readLock(baseDir);
+      if (pid === null || !isProcessAlive(pid)) {
+        // Orchestrator exited - auto-exit dashboard
+        exit();
+      }
+    }
+  }, 1000);
+  return () => clearInterval(timer);
+}, [baseDir, exit]);
+```
+[VERIFIED: readLock/isProcessAlive from lock.ts, useEffect polling pattern from use-status-poller.ts]
+
+### Anti-Patterns to Avoid
+- **fs.watch for signal file detection:** Platform-dependent behavior, race conditions with atomic rename, unnecessary complexity. Use polling instead -- the orchestrator already polls status files at 2s intervals. [CITED: https://nodejs.org/api/fs.html#caveats]
+- **process.on instead of process.once for signals:** Multiple handlers firing causes double-shutdown. Use `process.once` with a shutdown guard flag. [VERIFIED: current code uses process.once in lock.ts:84-86]
+- **Mutating shutdown state in the scheduler:** Use immutable patterns. The `shouldShutdown` callback returns a fresh read each time; no shared mutable state.
+- **AbortController threading:** Too invasive for v1 per CONTEXT.md decision. The between-issue polling is sufficient and much simpler.
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| Atomic file writes | Manual write+fsync | tmp+rename pattern | Already proven in status-manager.ts; rename is atomic on POSIX [VERIFIED: codebase] |
+| Process kill escalation | Custom SIGTERM/SIGKILL logic | Existing `killWorker()` | Already implements SIGTERM -> 5s timeout -> SIGKILL with polling [VERIFIED: worker-manager.ts:208-250] |
+| Status file validation | Manual JSON parsing | Existing `readGroupStatus()` | Already validates schema, handles malformed files [VERIFIED: status-manager.ts:26-39] |
+| PR merge detection | Custom GitHub API calls | Existing `gh pr view` pattern | merge-detector.ts already handles GitHub API + git fallback [VERIFIED: codebase] |
+| File-based polling | Custom setInterval wrapper | Follow merge-detector.ts timer pattern | stopped/completed guards, clearTimers cleanup [VERIFIED: merge-detector.ts:40-68] |
+
+**Key insight:** This phase mostly wires existing primitives together in new ways. The codebase already has atomic writes, process killing, status reconciliation, and polling infrastructure. The new code is primarily coordination logic.
+
+## Common Pitfalls
+
+### Pitfall 1: Double Shutdown / Re-entrancy
+**What goes wrong:** SIGINT arrives while graceful shutdown is already in progress, causing concurrent state writes or double lock release.
+**Why it happens:** `process.once('SIGINT')` fires independently of any in-progress shutdown coordination.
+**How to avoid:** Guard shutdown function with a `let shuttingDown = false` flag. Second signal either no-ops (graceful) or escalates to force.
+**Warning signs:** "Lock file not found" errors during shutdown, corrupted status files.
+
+### Pitfall 2: Orphaned Child Processes
+**What goes wrong:** Orchestrator exits but spawned `claude` processes continue running, consuming resources and potentially committing to branches.
+**Why it happens:** Child processes spawned with `spawn()` are not automatically killed when the parent exits. `process.on('exit')` handler cannot do async work.
+**How to avoid:** For graceful shutdown, wait for current `processIssue` to complete (workers exit naturally). For force shutdown, call `killWorker()` for all active PIDs before exiting. Track active worker PIDs in a Set.
+**Warning signs:** `claude` processes visible in `ps` after orchestrator exits.
+
+### Pitfall 3: Shutdown File Persists After Crash
+**What goes wrong:** Orchestrator crashes without cleaning up `.orchestrator/shutdown`. Next `orchestrator start` reads stale shutdown file and immediately shuts down.
+**Why it happens:** Crash or SIGKILL doesn't run cleanup handlers.
+**How to avoid:** `handleStart()` should always call `clearShutdownFile()` before starting orchestration. The shutdown file is transient IPC, not persistent state.
+**Warning signs:** Orchestrator exits immediately after start with no work done.
+
+### Pitfall 4: Promise.allSettled Groups During Force Shutdown
+**What goes wrong:** `assignWork()` uses `Promise.allSettled()` to run multiple groups concurrently. Force shutdown needs to kill workers across ALL groups, not just the one that noticed the shutdown signal.
+**Why it happens:** Each `processGroup` runs independently. If only one group checks `shouldShutdown()`, others continue.
+**How to avoid:** Force shutdown should kill ALL tracked worker PIDs directly (not go through the scheduler). The shutdown coordinator maintains the active PID set and kills them all. The `Promise.allSettled` results will reflect the killed workers.
+**Warning signs:** Some groups continue running during "force" shutdown.
+
+### Pitfall 5: Resume Skips Reconciliation
+**What goes wrong:** Status files say "coding" but the branch was force-pushed or rebased externally. Orchestrator tries to continue from a state that doesn't exist.
+**Why it happens:** Status files are a cache of what the orchestrator THINKS happened. Git is the source of truth.
+**How to avoid:** Always run `reconcile()` before resume. The existing `reconcile()` already resets status when branches are missing or have no commits. Extend it to also check for merged PRs.
+**Warning signs:** Worktree creation fails on resume, or commits are applied to wrong base.
+
+### Pitfall 6: Race Between Dashboard Write and Orchestrator Poll
+**What goes wrong:** Dashboard writes "graceful", then user presses `q` again to upgrade to "force", but orchestrator already read "graceful" and is draining.
+**Why it happens:** File-based IPC has inherent read-write race window.
+**How to avoid:** Orchestrator should re-read the shutdown file periodically during drain (e.g., while waiting for current issue to finish). If mode changed to "force" during drain, escalate immediately.
+**Warning signs:** Dashboard says "force killing" but orchestrator is still waiting for issue completion.
+
+## Code Examples
+
+### Shutdown-Aware processGroup Loop
+```typescript
+// Source: derived from scheduler.ts:248-254
+async function processGroup(
+  group: PRGroup,
+  config: OrchestratorConfig,
+  deps: SchedulerDeps,
+  now: () => string,
+): Promise<ProcessGroupResult> {
+  // ... existing slug derivation and status init ...
+
+  const status = deps.readGroupStatus(slug) ?? initGroupStatus(group, slug, now);
+  const remaining = status.issues_remaining;
+
+  for (const issueNumber of remaining) {
+    // Shutdown check point — between issues only
+    const shutdown = deps.shouldShutdown?.();
+    if (shutdown) {
+      safeWriteStatus(deps, slug, {
+        ...freshStatus(slug, group, deps, now),
+        current_issue: null,
+        step: 'idle',
+        step_result: 'interrupted',
+        last_updated: now(),
+      });
+      return {
+        completed: false,
+        error: `shutdown requested (${shutdown.mode})`,
+        shutdown: true,
+      };
+    }
+
+    const result = await processIssue(group, issueNumber, slug, config, deps, now);
+    if (!result.success) {
+      return { completed: false, failedIssue: issueNumber, error: result.error };
+    }
+  }
+
+  // ... existing self-review, PR creation, merge detection ...
+}
+```
+
+### Enhanced Signal Handlers
+```typescript
+// Source: derived from lock.ts:79-90
+export function installSignalHandlers(
+  onShutdown: () => void,
+  baseDir?: string,
+): void {
+  let shuttingDown = false;
+
+  const signalHandler = () => {
+    if (shuttingDown) return; // Prevent re-entrancy
+    shuttingDown = true;
+    onShutdown(); // Triggers graceful shutdown coordinator
+  };
+
+  process.once('SIGINT', signalHandler);
+  process.once('SIGTERM', signalHandler);
+  process.once('exit', () => {
+    releaseLock(baseDir);
+  });
+}
+```
+
+### Resume Detection in handleStart
+```typescript
+// Source: derived from cli.tsx:41-76
+async function handleStart(args: readonly string[]): Promise<void> {
+  // ... existing arg parsing ...
+
+  // Always clear stale shutdown file
+  clearShutdownFile();
+
+  if (fresh) {
+    clearRuntimeState();
+  }
+
+  acquireLock();
+
+  // Detect resume: check for existing status files
+  const hasExistingStatus = existsSync('.orchestrator/status') &&
+    readdirSync('.orchestrator/status').some(f => f.endsWith('.json'));
+
+  if (hasExistingStatus && !fresh) {
+    process.stdout.write('Resuming from previous state...\n');
+    // reconcile() + detectMergedPRs() before orchestrate()
+  }
+
+  // ... orchestrate with resume-aware overrides ...
+}
+```
+
+## State of the Art
+
+| Old Approach | Current Approach | When Changed | Impact |
+|--------------|------------------|--------------|--------|
+| `process.exit(0)` in signal handlers | Graceful drain with state flush | This phase | Prevents orphaned workers, preserves resume state |
+| Fresh `mergedPRs = new Set()` on start | Resume-aware merged PR detection | This phase | Enables resume without re-doing completed work |
+| `q` = immediate dashboard exit | `q` = write shutdown file, monitor drain | This phase | Enables coordinated shutdown between dashboard and orchestrator |
+
+## Assumptions Log
+
+| # | Claim | Section | Risk if Wrong |
+|---|-------|---------|---------------|
+| A1 | Polling interval of 500ms-1000ms for shutdown file is sufficient responsiveness | Architecture Patterns | Low -- user would notice <1s delay at most; easily tunable |
+| A2 | `process.once('exit')` handler runs synchronously before exit | Code Examples | Medium -- if async cleanup needed in exit handler, it won't complete. Mitigation: do all async cleanup before calling process.exit() |
+| A3 | Dashboard and orchestrator always share the same `.orchestrator/` directory (same CWD) | Architecture Patterns | High -- if they don't, IPC fails entirely. Verified: both use `baseDir` parameter defaulting to `.` |
+
+## Open Questions
+
+1. **Worker PID Tracking for Force Shutdown**
+   - What we know: `spawnClaudeProcess` returns a `WorkerHandle` with `pid`. The scheduler calls `processGroup` via `Promise.allSettled`, so multiple groups may have active workers simultaneously.
+   - What's unclear: Where to maintain the active PID set. Options: (a) in the shutdown coordinator module, (b) as an addition to `SchedulerDeps`, (c) in `orchestrate.ts`.
+   - Recommendation: Add an `ActiveWorkerRegistry` to the shutdown coordinator. The `spawnWorker`/`spawnDirectWorker` wrappers in `orchestrate.ts` register PIDs on spawn and deregister on exit. Force shutdown iterates the registry.
+
+2. **Shutdown File Cleanup Responsibility**
+   - What we know: Shutdown file should be cleaned up after orchestrator exits. Dashboard should NOT clean it (orchestrator may still be reading it).
+   - What's unclear: Whether to clean in the `exit` handler or at the start of next run.
+   - Recommendation: Clean at start of next run (`handleStart` always calls `clearShutdownFile`). The `exit` handler is unreliable for cleanup (SIGKILL, crashes).
+
+3. **Resume: How to Detect Merged PRs Without Known PR Numbers**
+   - What we know: Status files have `branch` but no `pr_number` field. The plan file has `pr_number` but plan PR numbers are placeholders (0 for unassigned).
+   - What's unclear: How to map a resumed group to its actual GitHub PR number.
+   - Recommendation: Use `gh pr list --head <branch> --json number,state` to find PRs by branch name. This is reliable and already how the merge-detector works conceptually.
+
+## Validation Architecture
+
+### Test Framework
+| Property | Value |
+|----------|-------|
+| Framework | vitest ^3.0.0 |
+| Config file | vitest.config.ts |
+| Quick run command | `pnpm run test -- --run src/shutdown.test.ts` |
+| Full suite command | `pnpm run test` |
+
+### Phase Requirements -> Test Map
+| Req ID | Behavior | Test Type | Automated Command | File Exists? |
+|--------|----------|-----------|-------------------|-------------|
+| SD-01 | Write/read/clear shutdown signal file | unit | `pnpm run test -- --run src/shutdown.test.ts` | No -- Wave 0 |
+| SD-02 | Graceful shutdown: finish current issue, write interrupted, exit | unit | `pnpm run test -- --run src/scheduler.test.ts` | Exists (extend) |
+| SD-03 | Force shutdown: SIGTERM all workers | unit | `pnpm run test -- --run src/shutdown.test.ts` | No -- Wave 0 |
+| SD-04 | Double-q detection in TUI | unit | `pnpm run test -- --run src/tui/use-keyboard.test.ts` | No -- Wave 0 (need new test file) |
+| SD-05 | Dashboard footer shows shutdown status | unit | `pnpm run test -- --run src/tui/Footer.test.ts` | No -- Wave 0 |
+| SD-06 | Dashboard auto-exits when lock gone | unit | `pnpm run test -- --run src/tui/Dashboard.test.ts` | No -- Wave 0 |
+| SD-07 | Resume detection + reconcile on start | unit | `pnpm run test -- --run src/resume.test.ts` | No -- Wave 0 |
+| SD-08 | Signal handlers trigger shutdown coordinator | unit | `pnpm run test -- --run src/lock.test.ts` | Exists (extend) |
+| SD-09 | Stale shutdown file cleared on start | unit | `pnpm run test -- --run src/cli.test.ts` | Exists (extend) |
+| SD-10 | Merged PR detection via gh CLI | unit | `pnpm run test -- --run src/resume.test.ts` | No -- Wave 0 |
+
+### Sampling Rate
+- **Per task commit:** `pnpm run test -- --run src/shutdown.test.ts src/resume.test.ts src/scheduler.test.ts`
+- **Per wave merge:** `pnpm run test`
+- **Phase gate:** Full suite green before `/gsd-verify-work`
+
+### Wave 0 Gaps
+- [ ] `src/shutdown.test.ts` -- covers SD-01, SD-03 (signal file CRUD, force kill coordination)
+- [ ] `src/resume.test.ts` -- covers SD-07, SD-10 (resume detection, merged PR detection)
+- [ ] `src/tui/use-keyboard.test.ts` -- covers SD-04 (double-q detection; file may need creating or extending)
+- [ ] `src/tui/Footer.test.ts` -- covers SD-05 (conditional shutdown status rendering)
+
+## Security Domain
+
+### Applicable ASVS Categories
+
+| ASVS Category | Applies | Standard Control |
+|---------------|---------|-----------------|
+| V2 Authentication | No | N/A -- local CLI tool |
+| V3 Session Management | No | N/A |
+| V4 Access Control | No | Lock file already prevents concurrent access [VERIFIED: lock.ts] |
+| V5 Input Validation | Yes | Validate shutdown file JSON schema before acting on it |
+| V6 Cryptography | No | N/A |
+
+### Known Threat Patterns
+
+| Pattern | STRIDE | Standard Mitigation |
+|---------|--------|---------------------|
+| Malicious shutdown file injection | Tampering | Validate JSON schema strictly; shutdown file path is deterministic and local-only |
+| Path traversal in baseDir | Tampering | Already mitigated by `path.resolve()` usage throughout codebase |
+| Signal handler denial of service | Denial of Service | Re-entrancy guard prevents recursive shutdown attempts |
+
+## Sources
+
+### Primary (HIGH confidence)
+- Codebase analysis: `src/scheduler.ts`, `src/lock.ts`, `src/worker-manager.ts`, `src/status-manager.ts`, `src/merge-detector.ts`, `src/orchestrate.ts`, `src/cli.tsx`, `src/tui/use-keyboard.ts`, `src/tui/Dashboard.tsx`, `src/tui/launch.ts`, `src/types.ts`
+- Context7 `/vadimdemedes/ink` -- useInput hook API, useApp exit pattern
+- Node.js official docs -- fs.watch caveats, process signal handling
+
+### Secondary (MEDIUM confidence)
+- [Graceful Shutdown in Node.js (DEV Community)](https://dev.to/superiqbal7/graceful-shutdown-in-nodejs-handling-stranger-danger-29jo) -- signal handling patterns
+- [Node.js fs.watch documentation](https://nodejs.org/api/fs.html) -- caveats about platform-dependent behavior
+- [Die, Child Process, Die! (Ex Ratione)](https://www.exratione.com/2013/05/die-child-process-die/) -- child process cleanup patterns
+
+### Tertiary (LOW confidence)
+- None -- all claims verified against codebase or official documentation.
+
+## Metadata
+
+**Confidence breakdown:**
+- Standard stack: HIGH -- no new dependencies, all patterns exist in codebase
+- Architecture: HIGH -- straightforward file-based IPC with well-understood patterns
+- Pitfalls: HIGH -- derived from direct codebase analysis of existing concurrency patterns
+- Resume logic: MEDIUM -- resume decision tree is well-defined in CONTEXT.md but merged PR detection path needs implementation
+
+**Research date:** 2026-05-03
+**Valid until:** 2026-06-03 (stable domain, no external API changes expected)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -13,3 +13,4 @@
 - [PR #22: Scheduler + E2E Integration](reviews/pr-022-scheduler-e2e.md) — 2 review rounds, all issues resolved, 282 tests pass
 - [PR #23: TUI Dashboard](reviews/pr-023-tui-dashboard.md) — 4 review rounds, all critical/high resolved, 384 tests pass
 - [PR #24: Resilience](reviews/pr-024-resilience.md) — 6 review rounds, all critical/high resolved, 469 tests pass
+- [PR #25: Shutdown + Resume](reviews/pr-025-shutdown-resume.md) — 4 review rounds, all critical/high resolved, 515 tests pass

--- a/docs/guide/claude-orchestrator-pr-plan.md
+++ b/docs/guide/claude-orchestrator-pr-plan.md
@@ -6,7 +6,7 @@ tags:
   - orchestrator
 created: 2026-05-02
 updated: 2026-05-04
-status: active
+status: completed
 related:
   - "[Parent Epic: #1](https://github.com/aaronhsyong2/claude-orchestrator/issues/1)"
   - "[PRD v2](claude-orchestrator-prd-v2.md)"
@@ -96,11 +96,12 @@ Logical grouping of issues from the Claude Orchestrator epic (#1) into PRs, orde
 
 ## PR 7: Shutdown + Resume
 
-**Branch:** `feat/shutdown-resume`
-**Status:** pending
+**Branch:** `feat/resilience`
+**Status:** merged (PR #25)
+**Review:** [4 rounds, all critical/high issues resolved](../reviews/pr-025-shutdown-resume.md)
 
 | Issue | Title                                                            | Status |
 | ----- | ---------------------------------------------------------------- | ------ |
-| #18   | Graceful shutdown + auto-resume from state + git cross-reference | Open   |
+| #18   | Graceful shutdown + auto-resume from state + git cross-reference | Closed |
 
 > Depends on: PR 4

--- a/docs/reviews/pr-025-shutdown-resume.md
+++ b/docs/reviews/pr-025-shutdown-resume.md
@@ -1,0 +1,68 @@
+---
+title: "PR #25: Shutdown + Resume Review"
+category: review
+tags:
+  - shutdown
+  - resume
+  - graceful-shutdown
+  - signal-handling
+  - code-review
+created: 2026-05-04
+updated: 2026-05-04
+status: active
+related:
+  - "[PR Plan](../guide/claude-orchestrator-pr-plan.md)"
+  - "[PR #25](https://github.com/aaronhsyong2/claude-orchestrator/pull/25)"
+---
+
+# PR #25: Shutdown + Resume — Review Summary
+
+**Branch:** `feat/resilience`
+**Issues:** #18
+**Review cycles:** 4 (6 parallel agents per cycle)
+**Final verdict:** APPROVE — 0 critical, 0 high
+
+## Stats
+
+- 28 files changed (+3,330 lines)
+- 1 squashed commit
+- 515 tests pass (29 test files)
+- typecheck, lint, build all clean
+
+## What Was Built
+
+- **Shutdown coordinator** (`src/shutdown.ts`) — file-based IPC shutdown signaling with atomic write, worker PID registry, force-kill support
+- **Resume module** (`src/resume.ts`) — detects existing state, reconciles with git, detects merged PRs via `gh`, resets to safe checkpoints
+- **Scheduler integration** (`src/scheduler.ts`) — shutdown checkpoint between issues, `step_result: 'interrupted'` on graceful stop
+- **Signal handlers** (`src/lock.ts`) — `onShutdown` callback with re-entrancy guard, SIGTERM/SIGINT registration
+- **Orchestrate wiring** (`src/orchestrate.ts`) — worker registry, resume detection, force kill, graceful shutdown callback
+- **CLI integration** (`src/cli.tsx`) — shutdown file IPC, resume detection logging, `--fresh` flag
+- **TUI integration** (`src/tui/`) — `q` writes graceful, double-`q` within 2s writes force, footer shows status, auto-exit on orchestrator termination
+
+## Review Rounds
+
+### Round 1 — Focused code review
+- 2 HIGH: temporal dead zone in worker wrappers, leaked setTimeout in poll effect
+- 4 MEDIUM: swallowed catches (readShutdownFile, hasExistingState), missing shutdownStatus in test fixture, writeShutdownFile unhandled in TUI
+- **All fixed**
+
+### Round 2 — Full 6-agent review
+- 2 HIGH: redundant clearShutdownFile timing window, buildGitState unchecked exitCode
+- 3 MEDIUM: useEffect re-entry after exited, misleading comment, writeShutdownFile unhandled in signal callback
+- **All fixed** (except awaiting-merge 24h block — tracked as design follow-up)
+
+### Round 3 — Full 6-agent review
+- 1 HIGH: auto-exit timeout cancelled by React effect cleanup (dashboard never closes)
+- 1 HIGH: resumeFromState unhandled throw aborts completely
+- **Both fixed** — separated polling and auto-exit into two effects; wrapped resume in try/catch with fresh-start fallback
+
+### Round 4 — Full 6-agent review
+- 0 new bugs found
+- Advisory items only (simplifications, type design, comments)
+- **Clean**
+
+## Tracked Follow-ups (not blocking)
+
+- `awaiting-merge` phase has no shutdown check (24h block) — design follow-up
+- Test gaps: double-q force upgrade, Footer rendering, resumeFromState integration
+- Advisory: GroupResult discriminated union, wrapSpawnWorker dedup, stale RESEARCH.md refs

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -3,7 +3,9 @@ import * as fs from 'node:fs';
 import { configExists, promptOverwrite, writeDefaultConfig } from './config.js';
 import { acquireLock, installSignalHandlers, releaseLock } from './lock.js';
 import { orchestrate } from './orchestrate.js';
+import { hasExistingState } from './resume.js';
 import { clearRuntimeState } from './runtime.js';
+import { clearShutdownFile, writeShutdownFile } from './shutdown.js';
 import { printStatus } from './status.js';
 import { launchDashboard } from './tui/launch.js';
 
@@ -60,11 +62,32 @@ async function handleStart(args: readonly string[]): Promise<void> {
 	}
 
 	acquireLock();
-	installSignalHandlers();
+	clearShutdownFile();
+	installSignalHandlers(() => {
+		// SIGINT/SIGTERM triggers graceful shutdown via IPC signal file
+		try {
+			writeShutdownFile('graceful');
+		} catch (err) {
+			process.stderr.write(
+				`[cli] failed to write shutdown file: ${err instanceof Error ? err.message : String(err)}\n`,
+			);
+		}
+		// Don't exit — let scheduler see the file and drain gracefully
+	});
 	process.stdout.write(`Acquired lock (.orchestrator/lock, PID ${process.pid})\n`);
 
+	if (!fresh && hasExistingState()) {
+		process.stdout.write('Detected previous state -- will reconcile and resume.\n');
+	}
+
 	try {
-		const result = await orchestrate(planPath, (msg) => process.stdout.write(`${msg}\n`));
+		const result = await orchestrate(planPath, (msg) => process.stdout.write(`${msg}\n`), {
+			onShutdown: (mode) => {
+				process.stdout.write(`Shutdown (${mode}) complete.\n`);
+				releaseLock();
+				process.exit(0);
+			},
+		});
 		const failed = result.results.filter((r) => !r.completed);
 		if (failed.length > 0) {
 			process.stderr.write(`Error: ${failed.length} group(s) failed\n`);

--- a/src/lock.test.ts
+++ b/src/lock.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
 	acquireLock,
 	getLockPath,
+	installSignalHandlers,
 	isLockStale,
 	isProcessAlive,
 	readLock,
@@ -102,5 +103,18 @@ describe('releaseLock', () => {
 		fs.writeFileSync(getLockPath(tmpDir), '12345\n');
 		releaseLock(tmpDir);
 		expect(readLock(tmpDir)).toBe(12345);
+	});
+});
+
+describe('installSignalHandlers with callback', () => {
+	it('accepts onShutdown callback without error', () => {
+		const callback = () => {};
+		// Should not throw when called with a callback
+		expect(() => installSignalHandlers(callback, tmpDir)).not.toThrow();
+	});
+
+	it('function signature accepts optional parameters', () => {
+		// Verify the function can be called with no arguments
+		expect(() => installSignalHandlers()).not.toThrow();
 	});
 });

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -76,11 +76,21 @@ export function releaseLock(baseDir?: string): void {
 	}
 }
 
-export function installSignalHandlers(baseDir?: string): void {
+export function installSignalHandlers(onShutdown?: () => void, baseDir?: string): void {
+	let shuttingDown = false;
+
 	const signalHandler = () => {
-		releaseLock(baseDir);
-		process.exit(0);
+		if (shuttingDown) return; // Prevent re-entrancy (RESEARCH.md pitfall #1)
+		shuttingDown = true;
+		if (onShutdown) {
+			onShutdown();
+		} else {
+			// Fallback: release lock and exit (backward compat)
+			releaseLock(baseDir);
+			process.exit(0);
+		}
 	};
+
 	process.once('SIGINT', signalHandler);
 	process.once('SIGTERM', signalHandler);
 	// Clean up lock on normal exit (e.g., event loop drains)

--- a/src/orchestrate.ts
+++ b/src/orchestrate.ts
@@ -2,7 +2,10 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { loadConfig as realLoadConfig } from './config.js';
 import { parsePlan as realParsePlan } from './parser.js';
+import { hasExistingState, resumeFromState } from './resume.js';
 import { assignWork, getReadyGroups } from './scheduler.js';
+import type { WorkerRegistry } from './shutdown.js';
+import { createWorkerRegistry, forceKillAll, readShutdownFile } from './shutdown.js';
 import {
 	deleteContext as realDeleteContext,
 	readContext as realReadContext,
@@ -14,10 +17,13 @@ import { notify as realNotify } from './tui/notification-service.js';
 import type {
 	AssignWorkResult,
 	ExecResult,
+	GitBranchState,
 	GroupStatus,
 	OrchestratorConfig,
 	PlanData,
 	SchedulerDeps,
+	ShutdownMode,
+	WorkerEvent,
 } from './types.js';
 import { verify as realVerify } from './verification.js';
 import {
@@ -33,6 +39,70 @@ export interface OrchestrateOverrides {
 	readonly loadConfig?: () => OrchestratorConfig;
 	readonly parsePlan?: (filePath: string) => Promise<PlanData>;
 	readonly deps?: SchedulerDeps;
+	readonly onShutdown?: (mode: ShutdownMode) => void;
+}
+
+async function buildGitState(
+	execCommand: (cmd: string, args: readonly string[], cwd: string) => Promise<ExecResult>,
+): Promise<GitBranchState> {
+	const branchResult = await execCommand(
+		'git',
+		['branch', '--list', '--format=%(refname:short)'],
+		'.',
+	);
+	if (branchResult.exitCode !== 0) {
+		throw new Error(`git branch failed (exit ${branchResult.exitCode}): ${branchResult.stderr}`);
+	}
+	const branches = branchResult.stdout
+		.split('\n')
+		.map((b) => b.trim())
+		.filter((b) => b.length > 0);
+
+	const branchHasCommits = new Map<string, boolean>();
+	for (const branch of branches) {
+		const logResult = await execCommand('git', ['log', '--oneline', '-1', branch], '.');
+		branchHasCommits.set(branch, logResult.exitCode === 0 && logResult.stdout.trim().length > 0);
+	}
+
+	return { branches, branchHasCommits };
+}
+
+function wrapSpawnWorker(
+	original: SchedulerDeps['spawnWorker'],
+	registry: WorkerRegistry,
+): SchedulerDeps['spawnWorker'] {
+	return (issue, groupSlug, worktreePath, onEvent, contextContent?) => {
+		let pid = -1;
+		const wrappedOnEvent = (event: WorkerEvent): void => {
+			if (event.event === 'exited') {
+				registry.deregister(pid);
+			}
+			onEvent(event);
+		};
+		const handle = original(issue, groupSlug, worktreePath, wrappedOnEvent, contextContent);
+		pid = handle.pid;
+		registry.register(pid);
+		return handle;
+	};
+}
+
+function wrapSpawnDirectWorker(
+	original: SchedulerDeps['spawnDirectWorker'],
+	registry: WorkerRegistry,
+): SchedulerDeps['spawnDirectWorker'] {
+	return (id, groupSlug, worktreePath, onEvent, prompt) => {
+		let pid = -1;
+		const wrappedOnEvent = (event: WorkerEvent): void => {
+			if (event.event === 'exited') {
+				registry.deregister(pid);
+			}
+			onEvent(event);
+		};
+		const handle = original(id, groupSlug, worktreePath, wrappedOnEvent, prompt);
+		pid = handle.pid;
+		registry.register(pid);
+		return handle;
+	};
 }
 
 export async function orchestrate(
@@ -44,8 +114,45 @@ export async function orchestrate(
 	const plan = await (overrides?.parsePlan ?? realParsePlan)(planPath);
 
 	const rawDeps = overrides?.deps ?? buildRealDeps();
-	const deps = wrapWithProgress(rawDeps, onProgress);
+	const progressDeps = wrapWithProgress(rawDeps, onProgress);
+
+	// Create worker PID registry for force shutdown
+	const registry = createWorkerRegistry();
+
+	// Build shouldShutdown callback for scheduler
+	const shouldShutdown = () => readShutdownFile();
+
+	// Resume detection: reconcile state with git before scheduling
 	const mergedPRs = new Set<number>();
+	if (hasExistingState()) {
+		onProgress('Resuming from previous state -- reconciling with git...');
+		try {
+			const gitState = await buildGitState(rawDeps.execCommand ?? realExecCommand);
+			const resumeResult = await resumeFromState(gitState, rawDeps.execCommand ?? realExecCommand);
+			for (const correction of resumeResult.corrections) {
+				onProgress(`  Reconciled: ${correction.slug} -- ${correction.reason}`);
+			}
+			for (const mergedBranch of resumeResult.mergedBranches) {
+				const matchingGroup = plan.groups.find((g) => g.branch === mergedBranch);
+				if (matchingGroup) {
+					mergedPRs.add(matchingGroup.pr_number);
+					onProgress(`  Already merged: PR #${matchingGroup.pr_number} (${mergedBranch})`);
+				}
+			}
+		} catch (err) {
+			process.stderr.write(
+				`[orchestrate] resume failed, continuing with fresh state: ${err instanceof Error ? err.message : String(err)}\n`,
+			);
+		}
+	}
+
+	// Wire shutdown + registry into deps
+	const trackedDeps: SchedulerDeps = {
+		...progressDeps,
+		shouldShutdown,
+		spawnWorker: wrapSpawnWorker(progressDeps.spawnWorker, registry),
+		spawnDirectWorker: wrapSpawnDirectWorker(progressDeps.spawnDirectWorker, registry),
+	};
 
 	const ready = getReadyGroups(plan, mergedPRs);
 	const capped = ready.slice(0, config.max_concurrent_agents);
@@ -53,7 +160,21 @@ export async function orchestrate(
 		onProgress(`Starting PR ${group.pr_number}: ${group.title} [${group.branch}]`);
 	}
 
-	return assignWork(plan, mergedPRs, config, deps);
+	const result = await assignWork(plan, mergedPRs, config, trackedDeps);
+
+	// Check if any group was interrupted by shutdown
+	const shutdownGroup = result.results.find((r) => r.shutdown);
+	if (shutdownGroup) {
+		const signal = readShutdownFile();
+		if (signal?.mode === 'force') {
+			await forceKillAll(registry, rawDeps.killWorker ?? realKillWorker);
+			overrides?.onShutdown?.('force');
+		} else {
+			overrides?.onShutdown?.('graceful');
+		}
+	}
+
+	return result;
 }
 
 const execFileAsync = promisify(execFile);

--- a/src/resume.test.ts
+++ b/src/resume.test.ts
@@ -1,0 +1,249 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { detectMergedPRs, hasExistingState, resetToCheckpoint } from './resume.js';
+import type { ExecResult, GroupStatus } from './types.js';
+
+let tmpDir: string;
+
+const NOW = '2026-05-02T12:00:00.000Z';
+const now = () => NOW;
+
+function makeStatus(overrides: Partial<GroupStatus> = {}): GroupStatus {
+	return {
+		pr_group: 'test-group',
+		branch: 'feat/test',
+		current_issue: null,
+		step: 'idle',
+		step_result: '',
+		issues_completed: [],
+		issues_remaining: [1, 2],
+		last_updated: '2026-05-01T00:00:00.000Z',
+		...overrides,
+	};
+}
+
+beforeEach(() => {
+	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'orch-resume-'));
+});
+
+afterEach(() => {
+	fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('hasExistingState', () => {
+	it('returns false when status dir missing', () => {
+		expect(hasExistingState(tmpDir)).toBe(false);
+	});
+
+	it('returns false when status dir empty', () => {
+		fs.mkdirSync(path.join(tmpDir, '.orchestrator/status'), { recursive: true });
+		expect(hasExistingState(tmpDir)).toBe(false);
+	});
+
+	it('returns true when status dir has .json files', () => {
+		const statusDir = path.join(tmpDir, '.orchestrator/status');
+		fs.mkdirSync(statusDir, { recursive: true });
+		fs.writeFileSync(path.join(statusDir, 'group-a.json'), '{}');
+		expect(hasExistingState(tmpDir)).toBe(true);
+	});
+
+	it('returns false when status dir has only non-json files', () => {
+		const statusDir = path.join(tmpDir, '.orchestrator/status');
+		fs.mkdirSync(statusDir, { recursive: true });
+		fs.writeFileSync(path.join(statusDir, 'readme.txt'), 'hello');
+		expect(hasExistingState(tmpDir)).toBe(false);
+	});
+});
+
+describe('resetToCheckpoint', () => {
+	const emptyMerged: ReadonlySet<string> = new Set();
+
+	it('idle + pass + no remaining -> resets to idle with empty step_result', () => {
+		const status = makeStatus({
+			step: 'idle',
+			step_result: 'pass',
+			issues_remaining: [],
+		});
+		const result = resetToCheckpoint(status, emptyMerged, now);
+		expect(result.step).toBe('idle');
+		expect(result.step_result).toBe('');
+		expect(result.current_issue).toBeNull();
+		expect(result.last_updated).toBe(NOW);
+	});
+
+	it('reviewing -> resets to idle', () => {
+		const status = makeStatus({ step: 'reviewing', step_result: 'cycle 1' });
+		const result = resetToCheckpoint(status, emptyMerged, now);
+		expect(result.step).toBe('idle');
+		expect(result.step_result).toBe('');
+		expect(result.current_issue).toBeNull();
+	});
+
+	it('pr-creating -> resets to idle', () => {
+		const status = makeStatus({ step: 'pr-creating' });
+		const result = resetToCheckpoint(status, emptyMerged, now);
+		expect(result.step).toBe('idle');
+		expect(result.step_result).toBe('');
+	});
+
+	it('pr-reviewing -> resets to idle', () => {
+		const status = makeStatus({ step: 'pr-reviewing' });
+		const result = resetToCheckpoint(status, emptyMerged, now);
+		expect(result.step).toBe('idle');
+		expect(result.step_result).toBe('');
+	});
+
+	it('awaiting-merge + branch merged -> marks fully done', () => {
+		const status = makeStatus({
+			step: 'awaiting-merge',
+			branch: 'feat/merged-branch',
+			issues_remaining: [1, 2],
+		});
+		const mergedSet: ReadonlySet<string> = new Set(['feat/merged-branch']);
+		const result = resetToCheckpoint(status, mergedSet, now);
+		expect(result.step).toBe('idle');
+		expect(result.step_result).toBe('pass');
+		expect(result.current_issue).toBeNull();
+		expect(result.issues_remaining).toEqual([]);
+	});
+
+	it('awaiting-merge + branch NOT merged -> returns unchanged', () => {
+		const status = makeStatus({
+			step: 'awaiting-merge',
+			branch: 'feat/pending-branch',
+		});
+		const result = resetToCheckpoint(status, emptyMerged, now);
+		// Should return exact same reference (unchanged)
+		expect(result).toBe(status);
+	});
+
+	it('coding -> resets to idle (current_issue preserved for retry)', () => {
+		const status = makeStatus({
+			step: 'coding',
+			current_issue: 42,
+		});
+		const result = resetToCheckpoint(status, emptyMerged, now);
+		expect(result.step).toBe('idle');
+		expect(result.step_result).toBe('');
+		expect(result.current_issue).toBe(42);
+	});
+
+	it('cloning -> resets to idle (current_issue preserved)', () => {
+		const status = makeStatus({ step: 'cloning', current_issue: 10 });
+		const result = resetToCheckpoint(status, emptyMerged, now);
+		expect(result.step).toBe('idle');
+		expect(result.step_result).toBe('');
+		expect(result.current_issue).toBe(10);
+	});
+
+	it('verifying -> resets to idle (current_issue preserved)', () => {
+		const status = makeStatus({ step: 'verifying', current_issue: 10 });
+		const result = resetToCheckpoint(status, emptyMerged, now);
+		expect(result.step).toBe('idle');
+		expect(result.step_result).toBe('');
+		expect(result.current_issue).toBe(10);
+	});
+
+	it('idle + interrupted -> resets step_result to empty', () => {
+		const status = makeStatus({
+			step: 'idle',
+			step_result: 'interrupted',
+		});
+		const result = resetToCheckpoint(status, emptyMerged, now);
+		expect(result.step).toBe('idle');
+		expect(result.step_result).toBe('');
+		expect(result.last_updated).toBe(NOW);
+	});
+
+	it('unknown/default idle state -> returns unchanged', () => {
+		const status = makeStatus({
+			step: 'idle',
+			step_result: 'some-other-value',
+			issues_remaining: [1],
+		});
+		const result = resetToCheckpoint(status, emptyMerged, now);
+		// Default branch: return unchanged
+		expect(result).toBe(status);
+	});
+});
+
+describe('detectMergedPRs', () => {
+	it('returns merged branches when gh reports merged PRs', async () => {
+		const mockExec = vi
+			.fn<(cmd: string, args: readonly string[], cwd: string) => Promise<ExecResult>>()
+			.mockResolvedValue({
+				exitCode: 0,
+				stdout: JSON.stringify([{ number: 42, state: 'MERGED' }]),
+				stderr: '',
+			});
+
+		const statuses: readonly GroupStatus[] = [
+			makeStatus({ step: 'awaiting-merge', branch: 'feat/merged-one' }),
+		];
+
+		const result = await detectMergedPRs(statuses, mockExec);
+		expect(result).toEqual(['feat/merged-one']);
+	});
+
+	it('returns empty array for no awaiting-merge statuses', async () => {
+		const mockExec = vi
+			.fn<(cmd: string, args: readonly string[], cwd: string) => Promise<ExecResult>>()
+			.mockResolvedValue({
+				exitCode: 0,
+				stdout: '[]',
+				stderr: '',
+			});
+
+		const statuses: readonly GroupStatus[] = [
+			makeStatus({ step: 'coding', branch: 'feat/coding-branch' }),
+			makeStatus({ step: 'idle', branch: 'feat/idle-branch' }),
+		];
+
+		const result = await detectMergedPRs(statuses, mockExec);
+		expect(result).toEqual([]);
+		expect(mockExec).not.toHaveBeenCalled();
+	});
+
+	it('handles gh command failure gracefully (returns empty, logs warning)', async () => {
+		const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+		const mockExec = vi
+			.fn<(cmd: string, args: readonly string[], cwd: string) => Promise<ExecResult>>()
+			.mockResolvedValue({
+				exitCode: 1,
+				stdout: '',
+				stderr: 'gh: not authenticated',
+			});
+
+		const statuses: readonly GroupStatus[] = [
+			makeStatus({ step: 'awaiting-merge', branch: 'feat/fail-branch' }),
+		];
+
+		const result = await detectMergedPRs(statuses, mockExec);
+		expect(result).toEqual([]);
+		expect(stderrSpy).toHaveBeenCalled();
+		stderrSpy.mockRestore();
+	});
+
+	it('skips non-awaiting-merge statuses', async () => {
+		const mockExec = vi
+			.fn<(cmd: string, args: readonly string[], cwd: string) => Promise<ExecResult>>()
+			.mockResolvedValue({
+				exitCode: 0,
+				stdout: JSON.stringify([{ number: 1, state: 'MERGED' }]),
+				stderr: '',
+			});
+
+		const statuses: readonly GroupStatus[] = [
+			makeStatus({ step: 'idle', branch: 'feat/idle' }),
+			makeStatus({ step: 'awaiting-merge', branch: 'feat/waiting' }),
+			makeStatus({ step: 'coding', branch: 'feat/coding' }),
+		];
+
+		const result = await detectMergedPRs(statuses, mockExec);
+		// Only the awaiting-merge status should trigger an exec call
+		expect(mockExec).toHaveBeenCalledTimes(1);
+		expect(result).toEqual(['feat/waiting']);
+	});
+});

--- a/src/resume.ts
+++ b/src/resume.ts
@@ -1,0 +1,188 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { readGroupStatus, reconcile, writeGroupStatus } from './status-manager.js';
+import type { ExecResult, GitBranchState, GroupStatus, ReconcileCorrection } from './types.js';
+
+export interface ResumeResult {
+	readonly corrections: readonly ReconcileCorrection[];
+	readonly mergedBranches: readonly string[];
+	readonly resetGroups: readonly string[];
+}
+
+export function hasExistingState(baseDir?: string): boolean {
+	const statusDir = path.resolve(baseDir ?? '.', '.orchestrator/status');
+
+	if (!fs.existsSync(statusDir)) {
+		return false;
+	}
+
+	try {
+		const entries = fs.readdirSync(statusDir);
+		return entries.some((f) => f.endsWith('.json'));
+	} catch (err: unknown) {
+		process.stderr.write(`[resume] failed to read status dir: ${String(err)}\n`);
+		return false;
+	}
+}
+
+export async function detectMergedPRs(
+	statuses: readonly GroupStatus[],
+	execCommand: (cmd: string, args: readonly string[], cwd: string) => Promise<ExecResult>,
+): Promise<readonly string[]> {
+	const merged: string[] = [];
+
+	for (const status of statuses) {
+		if (status.step !== 'awaiting-merge') {
+			continue;
+		}
+
+		try {
+			const result = await execCommand(
+				'gh',
+				['pr', 'list', '--head', status.branch, '--json', 'number,state', '--state', 'merged'],
+				'.',
+			);
+
+			if (result.exitCode !== 0) {
+				process.stderr.write(
+					`Warning: gh pr list failed for branch "${status.branch}": ${result.stderr}\n`,
+				);
+				continue;
+			}
+
+			const parsed: unknown = JSON.parse(result.stdout);
+			if (Array.isArray(parsed) && parsed.length > 0) {
+				merged.push(status.branch);
+			}
+		} catch (err: unknown) {
+			const message = err instanceof Error ? err.message : String(err);
+			process.stderr.write(
+				`Warning: failed to check merged status for branch "${status.branch}": ${message}\n`,
+			);
+		}
+	}
+
+	return merged;
+}
+
+export function resetToCheckpoint(
+	status: GroupStatus,
+	mergedBranches: ReadonlySet<string>,
+	now: () => string,
+): GroupStatus {
+	// All issues complete — reset to idle so scheduler re-enters self-review on next run
+	if (
+		status.step === 'idle' &&
+		status.step_result === 'pass' &&
+		status.issues_remaining.length === 0
+	) {
+		return {
+			...status,
+			step: 'idle',
+			step_result: '',
+			current_issue: null,
+			last_updated: now(),
+		};
+	}
+
+	// Died mid-phase (reviewing, pr-creating, pr-reviewing)
+	if (
+		status.step === 'reviewing' ||
+		status.step === 'pr-creating' ||
+		status.step === 'pr-reviewing'
+	) {
+		return {
+			...status,
+			step: 'idle',
+			step_result: '',
+			current_issue: null,
+			last_updated: now(),
+		};
+	}
+
+	// PR merged
+	if (status.step === 'awaiting-merge' && mergedBranches.has(status.branch)) {
+		return {
+			...status,
+			step: 'idle',
+			step_result: 'pass',
+			current_issue: null,
+			issues_remaining: [],
+			last_updated: now(),
+		};
+	}
+
+	// Awaiting merge but not merged -- keep as-is
+	if (status.step === 'awaiting-merge') {
+		return status;
+	}
+
+	// Died mid-issue (coding, cloning, verifying) -- keep current_issue so it gets retried
+	if (status.step === 'coding' || status.step === 'cloning' || status.step === 'verifying') {
+		return {
+			...status,
+			step: 'idle',
+			step_result: '',
+			last_updated: now(),
+		};
+	}
+
+	// Graceful shutdown interrupted
+	if (status.step === 'idle' && status.step_result === 'interrupted') {
+		return {
+			...status,
+			step: 'idle',
+			step_result: '',
+			last_updated: now(),
+		};
+	}
+
+	// Default: return unchanged
+	return status;
+}
+
+export async function resumeFromState(
+	gitState: GitBranchState,
+	execCommand: (cmd: string, args: readonly string[], cwd: string) => Promise<ExecResult>,
+	baseDir?: string,
+	now: () => string = () => new Date().toISOString(),
+): Promise<ResumeResult> {
+	// Step 1: reconcile status files with git state
+	const corrections = reconcile(gitState, baseDir, now);
+
+	// Step 2: read all status files
+	const statusDir = path.resolve(baseDir ?? '.', '.orchestrator/status');
+	const statuses: GroupStatus[] = [];
+	const slugs: string[] = [];
+
+	if (fs.existsSync(statusDir)) {
+		const files = fs.readdirSync(statusDir).filter((f) => f.endsWith('.json'));
+		for (const file of files) {
+			const slug = file.replace(/\.json$/, '');
+			const status = readGroupStatus(slug, baseDir);
+			if (status !== null) {
+				statuses.push(status);
+				slugs.push(slug);
+			}
+		}
+	}
+
+	// Step 3: detect merged PRs for awaiting-merge groups
+	const mergedBranches = await detectMergedPRs(statuses, execCommand);
+	const mergedSet: ReadonlySet<string> = new Set(mergedBranches);
+
+	// Step 4: reset each status to safe checkpoint
+	const resetGroups: string[] = [];
+
+	for (let i = 0; i < statuses.length; i++) {
+		const original = statuses[i];
+		const reset = resetToCheckpoint(original, mergedSet, now);
+
+		if (reset !== original) {
+			writeGroupStatus(slugs[i], reset, baseDir);
+			resetGroups.push(slugs[i]);
+		}
+	}
+
+	return { corrections, mergedBranches, resetGroups };
+}

--- a/src/scheduler.test.ts
+++ b/src/scheduler.test.ts
@@ -608,3 +608,148 @@ describe('onMerge', () => {
 		expect(result.assigned).toBe(0);
 	});
 });
+
+// --- processGroup shutdown checkpoint ---
+
+describe('processGroup shutdown', () => {
+	it('when shouldShutdown returns graceful signal, loop stops before next issue', async () => {
+		let callCount = 0;
+		const group = makeGroup({
+			pr_number: 1,
+			branch: 'feat/shutdown',
+			issues: [
+				{ number: 10, title: 'First', status: 'Open', blocked_by: [] },
+				{ number: 11, title: 'Second', status: 'Open', blocked_by: [] },
+			],
+		});
+
+		const spawnOrder: string[] = [];
+		const deps = createMockDeps({
+			shouldShutdown: () => {
+				callCount++;
+				// Return null on first call (before issue 10), signal on second (before issue 11)
+				if (callCount >= 2) {
+					return { mode: 'graceful' as const, requested_at: NOW };
+				}
+				return null;
+			},
+			spawnWorker: vi.fn(
+				(issue: string, _slug: string, _path: string, onEvent: (event: WorkerEvent) => void) => {
+					spawnOrder.push(issue);
+					process.nextTick(() => {
+						onEvent({
+							event: 'message',
+							data: { type: 'result', result: '[]', is_error: false },
+						});
+						onEvent({ event: 'exited', data: 0 });
+					});
+					return { id: `test-${issue}`, issue, groupSlug: 'feat-shutdown', pid: 123 };
+				},
+			),
+		});
+
+		const result = await assignWork(makePlan([group]), new Set(), BASE_CONFIG, deps, now);
+
+		// Only the first issue should be processed
+		expect(spawnOrder).toEqual(['10']);
+		expect(result.results[0]?.completed).toBe(false);
+		expect(result.results[0]?.shutdown).toBe(true);
+	});
+
+	it('status written with step_result interrupted on shutdown', async () => {
+		const group = makeGroup({
+			pr_number: 1,
+			branch: 'feat/int',
+			issues: [{ number: 10, title: 'Issue', status: 'Open', blocked_by: [] }],
+		});
+
+		const deps = createMockDeps({
+			shouldShutdown: () => ({ mode: 'graceful' as const, requested_at: NOW }),
+		});
+
+		await assignWork(makePlan([group]), new Set(), BASE_CONFIG, deps, now);
+
+		const writeStatusMock = vi.mocked(deps.writeGroupStatus);
+		const interruptedCalls = writeStatusMock.mock.calls.filter(
+			(call) => call[1].step_result === 'interrupted',
+		);
+		expect(interruptedCalls.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it('current issue completes before shutdown check (no mid-step interruption)', async () => {
+		let shouldShutdownCallCount = 0;
+		const group = makeGroup({
+			pr_number: 1,
+			branch: 'feat/complete-first',
+			issues: [
+				{ number: 10, title: 'First', status: 'Open', blocked_by: [] },
+				{ number: 11, title: 'Second', status: 'Open', blocked_by: [] },
+			],
+		});
+
+		const spawnOrder: string[] = [];
+		const deps = createMockDeps({
+			shouldShutdown: () => {
+				shouldShutdownCallCount++;
+				// Signal shutdown before second issue
+				if (shouldShutdownCallCount >= 2) {
+					return { mode: 'graceful' as const, requested_at: NOW };
+				}
+				return null;
+			},
+			spawnWorker: vi.fn(
+				(issue: string, _slug: string, _path: string, onEvent: (event: WorkerEvent) => void) => {
+					spawnOrder.push(issue);
+					process.nextTick(() => {
+						onEvent({
+							event: 'message',
+							data: { type: 'result', result: '[]', is_error: false },
+						});
+						onEvent({ event: 'exited', data: 0 });
+					});
+					return { id: `test-${issue}`, issue, groupSlug: 'feat-complete-first', pid: 123 };
+				},
+			),
+		});
+
+		await assignWork(makePlan([group]), new Set(), BASE_CONFIG, deps, now);
+
+		// First issue completed fully, second was not started
+		expect(spawnOrder).toEqual(['10']);
+	});
+
+	it('when shouldShutdown is undefined (backward compat), loop runs normally', async () => {
+		const group = makeGroup({
+			pr_number: 1,
+			branch: 'feat/no-shutdown',
+			issues: [
+				{ number: 10, title: 'First', status: 'Open', blocked_by: [] },
+				{ number: 11, title: 'Second', status: 'Open', blocked_by: [] },
+			],
+		});
+
+		const spawnOrder: string[] = [];
+		const deps = createMockDeps({
+			// shouldShutdown is NOT provided (undefined)
+			spawnWorker: vi.fn(
+				(issue: string, _slug: string, _path: string, onEvent: (event: WorkerEvent) => void) => {
+					spawnOrder.push(issue);
+					process.nextTick(() => {
+						onEvent({
+							event: 'message',
+							data: { type: 'result', result: '[]', is_error: false },
+						});
+						onEvent({ event: 'exited', data: 0 });
+					});
+					return { id: `test-${issue}`, issue, groupSlug: 'feat-no-shutdown', pid: 123 };
+				},
+			),
+		});
+
+		const result = await assignWork(makePlan([group]), new Set(), BASE_CONFIG, deps, now);
+
+		// Both issues processed
+		expect(spawnOrder.slice(0, 2)).toEqual(['10', '11']);
+		expect(result.results[0]?.completed).toBe(true);
+	});
+});

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -224,6 +224,7 @@ async function processGroup(
 	readonly completed: boolean;
 	readonly failedIssue?: number;
 	readonly error?: string;
+	readonly shutdown?: boolean;
 }> {
 	let slug: string;
 	try {
@@ -246,6 +247,23 @@ async function processGroup(
 	const remaining = status.issues_remaining;
 
 	for (const issueNumber of remaining) {
+		// Shutdown checkpoint — between issues only (per design: no mid-step interruption)
+		const shutdownSignal = deps.shouldShutdown?.();
+		if (shutdownSignal) {
+			safeWriteStatus(deps, slug, {
+				...freshStatus(slug, group, deps, now),
+				current_issue: null,
+				step: 'idle',
+				step_result: 'interrupted',
+				last_updated: now(),
+			});
+			return {
+				completed: false,
+				shutdown: true,
+				error: `shutdown requested (${shutdownSignal.mode})`,
+			};
+		}
+
 		const result = await processIssue(group, issueNumber, slug, config, deps, now);
 		if (!result.success) {
 			return { completed: false, failedIssue: issueNumber, error: result.error };

--- a/src/shutdown.test.ts
+++ b/src/shutdown.test.ts
@@ -1,0 +1,184 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	clearShutdownFile,
+	createWorkerRegistry,
+	forceKillAll,
+	getShutdownPath,
+	readShutdownFile,
+	writeShutdownFile,
+} from './shutdown.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'orch-shutdown-'));
+	fs.mkdirSync(path.join(tmpDir, '.orchestrator'), { recursive: true });
+});
+
+afterEach(() => {
+	fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('getShutdownPath', () => {
+	it('returns path ending in .orchestrator/shutdown', () => {
+		const result = getShutdownPath(tmpDir);
+		expect(result).toMatch(/\.orchestrator\/shutdown$/);
+	});
+
+	it('uses baseDir when provided', () => {
+		const result = getShutdownPath('/some/base');
+		expect(result).toBe(path.resolve('/some/base', '.orchestrator/shutdown'));
+	});
+});
+
+describe('writeShutdownFile', () => {
+	it('creates file with valid JSON containing mode and requested_at', () => {
+		writeShutdownFile('graceful', tmpDir);
+		const content = fs.readFileSync(getShutdownPath(tmpDir), 'utf-8');
+		const parsed = JSON.parse(content);
+		expect(parsed.mode).toBe('graceful');
+		expect(parsed.requested_at).toBeDefined();
+	});
+
+	it('creates directory if missing', () => {
+		const nested = path.join(tmpDir, 'deep', 'nested');
+		writeShutdownFile('graceful', nested);
+		expect(fs.existsSync(getShutdownPath(nested))).toBe(true);
+	});
+
+	it('overwrites existing file (graceful -> force upgrade)', () => {
+		writeShutdownFile('graceful', tmpDir);
+		writeShutdownFile('force', tmpDir);
+		const content = fs.readFileSync(getShutdownPath(tmpDir), 'utf-8');
+		const parsed = JSON.parse(content);
+		expect(parsed.mode).toBe('force');
+	});
+
+	it('mode graceful writes correct mode', () => {
+		writeShutdownFile('graceful', tmpDir);
+		const parsed = JSON.parse(fs.readFileSync(getShutdownPath(tmpDir), 'utf-8'));
+		expect(parsed.mode).toBe('graceful');
+	});
+
+	it('mode force writes correct mode', () => {
+		writeShutdownFile('force', tmpDir);
+		const parsed = JSON.parse(fs.readFileSync(getShutdownPath(tmpDir), 'utf-8'));
+		expect(parsed.mode).toBe('force');
+	});
+});
+
+describe('readShutdownFile', () => {
+	it('returns null when file missing', () => {
+		expect(readShutdownFile(tmpDir)).toBeNull();
+	});
+
+	it('returns ShutdownSignal for valid file', () => {
+		writeShutdownFile('graceful', tmpDir);
+		const result = readShutdownFile(tmpDir);
+		expect(result).not.toBeNull();
+		expect(result?.mode).toBe('graceful');
+		expect(result?.requested_at).toBeDefined();
+	});
+
+	it('returns null for malformed JSON', () => {
+		fs.writeFileSync(getShutdownPath(tmpDir), 'not-json{{{');
+		expect(readShutdownFile(tmpDir)).toBeNull();
+	});
+
+	it('returns null for invalid mode value', () => {
+		fs.writeFileSync(getShutdownPath(tmpDir), JSON.stringify({ mode: 'unknown' }));
+		expect(readShutdownFile(tmpDir)).toBeNull();
+	});
+});
+
+describe('clearShutdownFile', () => {
+	it('removes existing file', () => {
+		writeShutdownFile('graceful', tmpDir);
+		expect(fs.existsSync(getShutdownPath(tmpDir))).toBe(true);
+		clearShutdownFile(tmpDir);
+		expect(fs.existsSync(getShutdownPath(tmpDir))).toBe(false);
+	});
+
+	it('no-ops when file missing (no throw)', () => {
+		expect(() => clearShutdownFile(tmpDir)).not.toThrow();
+	});
+});
+
+describe('createWorkerRegistry', () => {
+	it('register adds PID, getActivePids returns it', () => {
+		const registry = createWorkerRegistry();
+		registry.register(123);
+		expect(registry.getActivePids()).toEqual([123]);
+	});
+
+	it('deregister removes PID', () => {
+		const registry = createWorkerRegistry();
+		registry.register(123);
+		registry.deregister(123);
+		expect(registry.getActivePids()).toEqual([]);
+	});
+
+	it('deregister no-ops for unknown PID', () => {
+		const registry = createWorkerRegistry();
+		registry.register(123);
+		registry.deregister(999);
+		expect(registry.getActivePids()).toEqual([123]);
+	});
+
+	it('getActivePids returns empty array initially', () => {
+		const registry = createWorkerRegistry();
+		expect(registry.getActivePids()).toEqual([]);
+	});
+
+	it('multiple register/deregister cycles work correctly', () => {
+		const registry = createWorkerRegistry();
+		registry.register(1);
+		registry.register(2);
+		registry.register(3);
+		registry.deregister(2);
+		registry.register(4);
+		registry.deregister(1);
+		const pids = registry.getActivePids();
+		expect(pids).toContain(3);
+		expect(pids).toContain(4);
+		expect(pids).not.toContain(1);
+		expect(pids).not.toContain(2);
+	});
+});
+
+describe('forceKillAll', () => {
+	it('calls killWorker for each active PID', async () => {
+		const mockKill = vi.fn().mockResolvedValue(undefined);
+		const registry = createWorkerRegistry();
+		registry.register(100);
+		registry.register(200);
+
+		await forceKillAll(registry, mockKill);
+
+		expect(mockKill).toHaveBeenCalledTimes(2);
+		expect(mockKill).toHaveBeenCalledWith(100);
+		expect(mockKill).toHaveBeenCalledWith(200);
+	});
+
+	it('handles empty registry (no calls)', async () => {
+		const mockKill = vi.fn().mockResolvedValue(undefined);
+		const registry = createWorkerRegistry();
+
+		await forceKillAll(registry, mockKill);
+
+		expect(mockKill).not.toHaveBeenCalled();
+	});
+
+	it('handles killWorker rejection gracefully (Promise.allSettled)', async () => {
+		const mockKill = vi.fn().mockRejectedValue(new Error('ESRCH'));
+		const registry = createWorkerRegistry();
+		registry.register(100);
+		registry.register(200);
+
+		// Should not throw despite rejections
+		await expect(forceKillAll(registry, mockKill)).resolves.not.toThrow();
+	});
+});

--- a/src/shutdown.ts
+++ b/src/shutdown.ts
@@ -1,0 +1,79 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { ShutdownMode, ShutdownSignal } from './types.js';
+
+export interface WorkerRegistry {
+	readonly register: (pid: number) => void;
+	readonly deregister: (pid: number) => void;
+	readonly getActivePids: () => readonly number[];
+}
+
+export function getShutdownPath(baseDir?: string): string {
+	return path.resolve(baseDir ?? '.', '.orchestrator/shutdown');
+}
+
+export function writeShutdownFile(mode: ShutdownMode, baseDir?: string): void {
+	const filePath = getShutdownPath(baseDir);
+	const dir = path.dirname(filePath);
+	fs.mkdirSync(dir, { recursive: true });
+
+	const signal: ShutdownSignal = {
+		mode,
+		requested_at: new Date().toISOString(),
+	};
+
+	// Atomic write via tmp+rename (same pattern as status-manager.ts:72-74)
+	const tmpPath = `${filePath}.tmp`;
+	fs.writeFileSync(tmpPath, `${JSON.stringify(signal, null, '\t')}\n`);
+	fs.renameSync(tmpPath, filePath);
+}
+
+export function readShutdownFile(baseDir?: string): ShutdownSignal | null {
+	const filePath = getShutdownPath(baseDir);
+	try {
+		const content = fs.readFileSync(filePath, 'utf-8');
+		const parsed = JSON.parse(content) as Record<string, unknown>;
+		if (parsed.mode === 'graceful' || parsed.mode === 'force') {
+			return {
+				mode: parsed.mode as ShutdownMode,
+				requested_at: String(parsed.requested_at ?? ''),
+			};
+		}
+		return null;
+	} catch (err: unknown) {
+		if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+		process.stderr.write(`[shutdown] failed to read shutdown file: ${String(err)}\n`);
+		return null;
+	}
+}
+
+export function clearShutdownFile(baseDir?: string): void {
+	try {
+		fs.unlinkSync(getShutdownPath(baseDir));
+	} catch (err: unknown) {
+		if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+			throw err;
+		}
+	}
+}
+
+export function createWorkerRegistry(): WorkerRegistry {
+	const pids = new Set<number>();
+
+	return {
+		register: (pid: number): void => {
+			pids.add(pid);
+		},
+		deregister: (pid: number): void => {
+			pids.delete(pid);
+		},
+		getActivePids: (): readonly number[] => Array.from(pids),
+	};
+}
+
+export async function forceKillAll(
+	registry: WorkerRegistry,
+	killWorker: (pid: number) => Promise<void>,
+): Promise<void> {
+	await Promise.allSettled(registry.getActivePids().map((pid) => killWorker(pid)));
+}

--- a/src/tui/Dashboard.tsx
+++ b/src/tui/Dashboard.tsx
@@ -36,14 +36,21 @@ export function Dashboard({
 	const notifConfig = config?.notifications ?? DEFAULT_CONFIG.notifications;
 	useNotifications(groups, notifConfig);
 
-	const { activePanel, selectedGroupIndex, selectedIssueIndex, screenMode, overlay, error } =
-		useKeyboard({
-			groups,
-			baseDir,
-			initialState,
-			onTakeover,
-			onQuit,
-		});
+	const {
+		activePanel,
+		selectedGroupIndex,
+		selectedIssueIndex,
+		screenMode,
+		overlay,
+		error,
+		shutdownStatus,
+	} = useKeyboard({
+		groups,
+		baseDir,
+		initialState,
+		onTakeover,
+		onQuit,
+	});
 
 	const selectedGroup = groups[selectedGroupIndex] ?? null;
 
@@ -81,7 +88,12 @@ export function Dashboard({
 					<Text color="red">{error}</Text>
 				</Box>
 			)}
-			<Footer activePanel={activePanel} screenMode={screenMode} overlay={overlay} />
+			<Footer
+				activePanel={activePanel}
+				screenMode={screenMode}
+				overlay={overlay}
+				shutdownStatus={shutdownStatus}
+			/>
 		</Box>
 	);
 }

--- a/src/tui/Footer.tsx
+++ b/src/tui/Footer.tsx
@@ -1,11 +1,12 @@
 import { Box, Text } from 'ink';
 import type { ReactNode } from 'react';
-import type { OverlayMode, ScreenMode } from './types.js';
+import type { OverlayMode, ScreenMode, ShutdownStatus } from './types.js';
 
 interface FooterProps {
 	readonly activePanel: number;
 	readonly screenMode: ScreenMode;
 	readonly overlay: OverlayMode;
+	readonly shutdownStatus: ShutdownStatus;
 }
 
 const NEXT_MODE: Record<ScreenMode, ScreenMode> = {
@@ -37,7 +38,35 @@ function getHints(
 	return hints;
 }
 
-export function Footer({ activePanel, screenMode, overlay }: FooterProps): ReactNode {
+export function Footer({
+	activePanel,
+	screenMode,
+	overlay,
+	shutdownStatus,
+}: FooterProps): ReactNode {
+	if (shutdownStatus === 'exited') {
+		return (
+			<Box>
+				<Text color="green">Orchestrator exited. Dashboard closing...</Text>
+			</Box>
+		);
+	}
+	if (shutdownStatus === 'force') {
+		return (
+			<Box>
+				<Text color="yellow">Force killing workers...</Text>
+			</Box>
+		);
+	}
+	if (shutdownStatus === 'graceful') {
+		return (
+			<Box>
+				<Text color="cyan">Shutting down -- waiting for workers... (q again to force kill)</Text>
+			</Box>
+		);
+	}
+
+	// Normal mode -- existing hint logic
 	const hints = getHints(activePanel, screenMode, overlay);
 	return (
 		<Box>

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -17,6 +17,8 @@ export interface TakeoverRequest {
 	readonly branch: string;
 }
 
+export type ShutdownStatus = 'none' | 'graceful' | 'force' | 'exited';
+
 export type PanelIndex = 0 | 1 | 2;
 
 export interface DashboardState {
@@ -25,4 +27,5 @@ export interface DashboardState {
 	readonly selectedIssueIndex: number;
 	readonly screenMode: ScreenMode;
 	readonly overlay: OverlayMode;
+	readonly shutdownStatus: ShutdownStatus;
 }

--- a/src/tui/use-keyboard.test.tsx
+++ b/src/tui/use-keyboard.test.tsx
@@ -2,6 +2,7 @@ import { Text } from 'ink';
 import { render } from 'ink-testing-library';
 import React, { act, type ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { writeShutdownFile } from '../shutdown.js';
 import type { GroupStatus } from '../types.js';
 import type { DashboardState, TakeoverRequest } from './types.js';
 import { useKeyboard } from './use-keyboard.js';
@@ -9,6 +10,17 @@ import { useKeyboard } from './use-keyboard.js';
 // Mock worktree-manager and node:fs for path resolution and existence checks
 vi.mock('../worktree-manager.js', () => ({
 	getWorktreePath: vi.fn((branch: string, _baseDir?: string) => `/worktrees/${branch}`),
+}));
+
+// Mock shutdown and lock modules used by use-keyboard
+vi.mock('../shutdown.js', () => ({
+	writeShutdownFile: vi.fn(),
+	readShutdownFile: vi.fn(() => null),
+}));
+
+vi.mock('../lock.js', () => ({
+	readLock: vi.fn(() => null),
+	isProcessAlive: vi.fn(() => false),
 }));
 
 const mockExistsSync = vi.fn((_path?: unknown) => true);
@@ -89,6 +101,7 @@ describe('useKeyboard', () => {
 			selectedIssueIndex: 1,
 			screenMode: 'half',
 			overlay: 'deps',
+			shutdownStatus: 'none',
 		};
 		const { lastFrame } = render(React.createElement(TestHarness, { groups, initialState }));
 		expect(lastFrame()).toContain('panel:1');
@@ -290,14 +303,16 @@ describe('useKeyboard', () => {
 	});
 
 	describe('q key (quit)', () => {
-		it('calls onQuit when provided', async () => {
+		it('writes graceful shutdown file on first q press', async () => {
 			const groups = [makeGroup()];
 			const onQuit = vi.fn();
 			const { stdin } = render(React.createElement(TestHarness, { groups, onQuit }));
 
 			await press(stdin, 'q');
 
-			expect(onQuit).toHaveBeenCalledOnce();
+			// q now writes shutdown file instead of calling onQuit directly
+			expect(writeShutdownFile).toHaveBeenCalledWith('graceful', '.');
+			expect(onQuit).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/tui/use-keyboard.ts
+++ b/src/tui/use-keyboard.ts
@@ -1,6 +1,8 @@
 import { existsSync } from 'node:fs';
 import { useApp, useInput } from 'ink';
 import { useEffect, useRef, useState } from 'react';
+import { isProcessAlive, readLock } from '../lock.js';
+import { readShutdownFile, writeShutdownFile } from '../shutdown.js';
 import type { GroupStatus } from '../types.js';
 import { getWorktreePath } from '../worktree-manager.js';
 import type {
@@ -8,6 +10,7 @@ import type {
 	OverlayMode,
 	PanelIndex,
 	ScreenMode,
+	ShutdownStatus,
 	TakeoverRequest,
 } from './types.js';
 
@@ -26,6 +29,7 @@ interface KeyboardState {
 	readonly screenMode: ScreenMode;
 	readonly overlay: OverlayMode;
 	readonly error: string | null;
+	readonly shutdownStatus: ShutdownStatus;
 }
 
 export function useKeyboard({
@@ -46,6 +50,11 @@ export function useKeyboard({
 	const [screenMode, setScreenMode] = useState<ScreenMode>(initialState?.screenMode ?? 'normal');
 	const [overlay, setOverlay] = useState<OverlayMode>(initialState?.overlay ?? 'none');
 	const [error, setError] = useState<string | null>(null);
+	const [shutdownStatus, setShutdownStatus] = useState<ShutdownStatus>(
+		initialState?.shutdownStatus ?? 'none',
+	);
+	const lastQPressRef = useRef<number>(0);
+	const DOUBLE_Q_THRESHOLD_MS = 2000;
 
 	// Auto-dismiss error after 3 seconds
 	useEffect(() => {
@@ -80,17 +89,57 @@ export function useKeyboard({
 		}
 	}, [issueCount, selectedIssueIndex]);
 
+	// Poll lock file after shutdown requested to detect orchestrator exit
+	useEffect(() => {
+		if (shutdownStatus === 'none' || shutdownStatus === 'exited') return;
+		const timer = setInterval(() => {
+			const pid = readLock(baseDir);
+			if (pid === null || !isProcessAlive(pid)) {
+				setShutdownStatus('exited');
+				clearInterval(timer);
+				return;
+			}
+			// Re-read shutdown file in case mode upgraded from graceful to force
+			const signal = readShutdownFile(baseDir);
+			if (signal?.mode === 'force' && shutdownStatus === 'graceful') {
+				setShutdownStatus('force');
+			}
+		}, 1000);
+		return () => clearInterval(timer);
+	}, [shutdownStatus, baseDir]);
+
+	// Auto-exit dashboard after showing "exited" status briefly
+	useEffect(() => {
+		if (shutdownStatus !== 'exited') return;
+		const timer = setTimeout(() => {
+			if (onQuit) {
+				onQuit();
+			} else {
+				exit();
+			}
+		}, 1500);
+		return () => clearTimeout(timer);
+	}, [shutdownStatus, onQuit, exit]);
+
 	const stateRef = useRef<DashboardState>({
 		activePanel,
 		selectedGroupIndex,
 		selectedIssueIndex,
 		screenMode,
 		overlay,
+		shutdownStatus,
 	});
 
 	useEffect(() => {
-		stateRef.current = { activePanel, selectedGroupIndex, selectedIssueIndex, screenMode, overlay };
-	}, [activePanel, selectedGroupIndex, selectedIssueIndex, screenMode, overlay]);
+		stateRef.current = {
+			activePanel,
+			selectedGroupIndex,
+			selectedIssueIndex,
+			screenMode,
+			overlay,
+			shutdownStatus,
+		};
+	}, [activePanel, selectedGroupIndex, selectedIssueIndex, screenMode, overlay, shutdownStatus]);
 
 	function currentState(): DashboardState {
 		return stateRef.current;
@@ -165,14 +214,41 @@ export function useKeyboard({
 		}
 
 		if (input === 'q') {
-			if (onQuit) {
-				onQuit();
-			} else {
-				exit();
+			const now = Date.now();
+			const elapsed = now - lastQPressRef.current;
+			lastQPressRef.current = now;
+
+			if (shutdownStatus !== 'none') {
+				// Already in shutdown -- subsequent q within threshold upgrades to force
+				if (elapsed < DOUBLE_Q_THRESHOLD_MS) {
+					try {
+						writeShutdownFile('force', baseDir);
+						setShutdownStatus('force');
+					} catch (err) {
+						setError(`Shutdown failed: ${err instanceof Error ? err.message : String(err)}`);
+					}
+				}
+				return;
+			}
+
+			// First q -- graceful shutdown
+			try {
+				writeShutdownFile('graceful', baseDir);
+				setShutdownStatus('graceful');
+			} catch (err) {
+				setError(`Shutdown failed: ${err instanceof Error ? err.message : String(err)}`);
 			}
 			return;
 		}
 	});
 
-	return { activePanel, selectedGroupIndex, selectedIssueIndex, screenMode, overlay, error };
+	return {
+		activePanel,
+		selectedGroupIndex,
+		selectedIssueIndex,
+		screenMode,
+		overlay,
+		error,
+		shutdownStatus,
+	};
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -144,6 +144,7 @@ export interface SchedulerDeps {
 	readonly deleteContext: (groupSlug: string, issue: string) => void;
 	readonly execCommand: (cmd: string, args: readonly string[], cwd: string) => Promise<ExecResult>;
 	readonly notify: (message: string, config: NotificationConfig) => Promise<void>;
+	readonly shouldShutdown?: () => ShutdownSignal | null;
 }
 
 export interface GroupResult {
@@ -152,6 +153,7 @@ export interface GroupResult {
 	readonly completed: boolean;
 	readonly failedIssue?: number;
 	readonly error?: string;
+	readonly shutdown?: boolean;
 }
 
 export interface AssignWorkResult {
@@ -276,4 +278,13 @@ export type MergeDetectorResult = 'merged' | 'closed' | 'timeout';
 
 export interface MergeDetectorHandle {
 	readonly stop: () => void;
+}
+
+// --- Shutdown types ---
+
+export type ShutdownMode = 'graceful' | 'force';
+
+export interface ShutdownSignal {
+	readonly mode: ShutdownMode;
+	readonly requested_at: string;
 }


### PR DESCRIPTION
## Summary

- Add file-based IPC shutdown signaling (`src/shutdown.ts`) and automatic resume on restart (`src/resume.ts`)
- Wire shutdown into scheduler, signal handlers, orchestrate entry point, and CLI
- TUI: `q` triggers graceful shutdown, double-`q` within 2s force-kills workers, footer shows shutdown status
- Auto-resume detects existing state, reconciles with git, detects merged PRs, resets to safe checkpoints

## Test plan

- [x] 46 new tests across `shutdown.test.ts`, `resume.test.ts`, `scheduler.test.ts`, `lock.test.ts`
- [x] Existing `use-keyboard.test.tsx` updated for new shutdown behavior
- [x] All 515 tests pass
- [x] `pnpm run check` (Biome) clean
- [x] `pnpm run build` (tsup) succeeds
- [x] Code review: 2 rounds, all HIGH/MEDIUM issues resolved

Closes #18