### PR TITLE
feat: human-readable worker logs + stuck detection + live activity in TUI (#41, #42)

### DIFF
--- a/docs/guide/first-run-fixes-pr-plan.md
+++ b/docs/guide/first-run-fixes-pr-plan.md
@@ -32,14 +32,15 @@ Logical grouping of issues from the first-run orchestrator fixes (#38) into PRs.
 ## PR 2: Observability — Readable Logs + Stuck Detection
 
 **Branch:** `feat/issue-41-42`
-**Status:** pending
+**PR:** [#51](https://github.com/aaronhsyong2/claude-orchestrator/pull/51)
+**Status:** open (review complete, ready to merge)
 
 | Issue | Title | Status |
 |-------|-------|--------|
-| #41 | Human-readable worker logs from NDJSON stream | Open |
-| #42 | Stuck detection + elapsed time + live activity in TUI | Open |
+| #41 | Human-readable worker logs from NDJSON stream | Closed |
+| #42 | Stuck detection + elapsed time + live activity in TUI | Closed |
 
-> Depends on: PR 1
+> Depends on: PR 1 (merged)
 
 ## PR 3: Session Manager + Session Resume
 

--- a/docs/guide/first-run-fixes-pr-plan.md
+++ b/docs/guide/first-run-fixes-pr-plan.md
@@ -6,7 +6,7 @@ tags:
   - first-run
   - dogfooding
 created: 2026-05-04
-updated: 2026-05-04
+updated: 2026-05-05
 status: active
 related:
   - "[Parent Epic: #38](https://github.com/aaronhsyong2/claude-orchestrator/issues/38)"
@@ -21,12 +21,13 @@ Logical grouping of issues from the first-run orchestrator fixes (#38) into PRs.
 ## PR 1: Test Isolation + Source Runner
 
 **Branch:** `fix/issue-39-40`
-**Status:** pending
+**PR:** [#50](https://github.com/aaronhsyong2/claude-orchestrator/pull/50)
+**Status:** merged
 
 | Issue | Title | Status |
 |-------|-------|--------|
-| #39 | Test isolation: all tests use temp baseDir | Open |
-| #40 | cli.test.ts: run from source via tsx instead of dist | Open |
+| #39 | Test isolation: all tests use temp baseDir | Closed |
+| #40 | cli.test.ts: run from source via tsx instead of dist | Closed |
 
 ## PR 2: Observability — Readable Logs + Stuck Detection
 

--- a/src/orchestrate.ts
+++ b/src/orchestrate.ts
@@ -7,6 +7,7 @@ import { assignWork, getReadyGroups } from './scheduler.js';
 import type { WorkerRegistry } from './shutdown.js';
 import { createWorkerRegistry, forceKillAll, readShutdownFile } from './shutdown.js';
 import {
+	appendToolActivity,
 	deleteContext as realDeleteContext,
 	readContext as realReadContext,
 	readGroupStatus as realReadGroupStatus,
@@ -68,6 +69,16 @@ async function buildGitState(
 	return { branches, branchHasCommits };
 }
 
+function handleToolActivity(event: WorkerEvent, groupSlug: string): void {
+	if (event.event === 'tool_activity') {
+		try {
+			appendToolActivity(groupSlug, event.data, new Date().toISOString());
+		} catch {
+			// Non-critical — don't crash worker pipeline for activity tracking
+		}
+	}
+}
+
 function wrapSpawnWorker(
 	original: SchedulerDeps['spawnWorker'],
 	registry: WorkerRegistry,
@@ -78,6 +89,7 @@ function wrapSpawnWorker(
 			if (event.event === 'exited') {
 				registry.deregister(pid);
 			}
+			handleToolActivity(event, groupSlug);
 			onEvent(event);
 		};
 		const handle = original(issue, groupSlug, worktreePath, wrappedOnEvent, contextContent);
@@ -97,6 +109,7 @@ function wrapSpawnDirectWorker(
 			if (event.event === 'exited') {
 				registry.deregister(pid);
 			}
+			handleToolActivity(event, groupSlug);
 			onEvent(event);
 		};
 		const handle = original(id, groupSlug, worktreePath, wrappedOnEvent, prompt);

--- a/src/orchestrate.ts
+++ b/src/orchestrate.ts
@@ -73,8 +73,10 @@ function handleToolActivity(event: WorkerEvent, groupSlug: string): void {
 	if (event.event === 'tool_activity') {
 		try {
 			appendToolActivity(groupSlug, event.data, new Date().toISOString());
-		} catch {
-			// Non-critical — don't crash worker pipeline for activity tracking
+		} catch (err: unknown) {
+			process.stderr.write(
+				`[orchestrate] activity tracking failed for ${groupSlug}: ${err instanceof Error ? err.message : String(err)}\n`,
+			);
 		}
 	}
 }

--- a/src/status-manager.test.ts
+++ b/src/status-manager.test.ts
@@ -3,16 +3,19 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+	appendToolActivity,
 	deleteContext,
 	getContextDir,
 	getGroupStatusPath,
 	readContext,
+	readGroupActivity,
 	readGroupStatus,
 	reconcile,
 	writeContext,
+	writeGroupActivity,
 	writeGroupStatus,
 } from './status-manager.js';
-import type { GitBranchState, GroupStatus } from './types.js';
+import type { GitBranchState, GroupActivity, GroupStatus } from './types.js';
 
 let tmpDir: string;
 
@@ -344,5 +347,95 @@ describe('reconcile', () => {
 		const corrections = reconcile(gitState, tmpDir);
 		expect(corrections).toHaveLength(1);
 		expect(corrections[0]?.slug).toBe('pr-2');
+	});
+});
+
+describe('writeGroupActivity / readGroupActivity', () => {
+	it('writes and reads activity file', () => {
+		const activity: GroupActivity = {
+			last_activity: '2026-05-05T10:02:30.000Z',
+			recent_actions: [
+				{ timestamp: '2026-05-05T10:02:30.000Z', message: 'Reading src/types.ts' },
+				{ timestamp: '2026-05-05T10:02:28.000Z', message: 'Running pnpm run test' },
+			],
+		};
+
+		writeGroupActivity('pr-1', activity, tmpDir);
+		const result = readGroupActivity('pr-1', tmpDir);
+
+		expect(result).toEqual(activity);
+	});
+
+	it('returns null when file does not exist', () => {
+		expect(readGroupActivity('pr-nonexistent', tmpDir)).toBeNull();
+	});
+
+	it('returns null for malformed JSON', () => {
+		const statusDir = path.join(tmpDir, '.orchestrator', 'status');
+		fs.mkdirSync(statusDir, { recursive: true });
+		fs.writeFileSync(path.join(statusDir, 'pr-1.activity.json'), 'not json');
+
+		expect(readGroupActivity('pr-1', tmpDir)).toBeNull();
+	});
+
+	it('caps recent_actions at 20 entries', () => {
+		const actions = Array.from({ length: 25 }, (_, i) => ({
+			timestamp: `2026-05-05T10:00:${String(i).padStart(2, '0')}.000Z`,
+			message: `Action ${i}`,
+		}));
+		const activity: GroupActivity = {
+			last_activity: '2026-05-05T10:00:24.000Z',
+			recent_actions: actions,
+		};
+
+		writeGroupActivity('pr-1', activity, tmpDir);
+		const result = readGroupActivity('pr-1', tmpDir);
+
+		expect(result?.recent_actions).toHaveLength(20);
+		// Keeps first 20 of input array (caller orders newest-first)
+		expect(result?.recent_actions[0]?.message).toBe('Action 0');
+	});
+
+	it('rejects invalid slug', () => {
+		const activity: GroupActivity = { last_activity: '', recent_actions: [] };
+		expect(() => writeGroupActivity('../evil', activity, tmpDir)).toThrow(/Invalid slug/);
+		expect(() => readGroupActivity('../evil', tmpDir)).toThrow(/Invalid slug/);
+	});
+});
+
+describe('appendToolActivity', () => {
+	it('creates activity file if none exists', () => {
+		appendToolActivity('pr-1', 'Reading src/types.ts', '2026-05-05T10:00:00.000Z', tmpDir);
+
+		const result = readGroupActivity('pr-1', tmpDir);
+		expect(result?.last_activity).toBe('2026-05-05T10:00:00.000Z');
+		expect(result?.recent_actions).toHaveLength(1);
+		expect(result?.recent_actions[0]?.message).toBe('Reading src/types.ts');
+	});
+
+	it('prepends new action and updates last_activity', () => {
+		appendToolActivity('pr-1', 'Reading src/types.ts', '2026-05-05T10:00:00.000Z', tmpDir);
+		appendToolActivity('pr-1', 'Running tests', '2026-05-05T10:00:05.000Z', tmpDir);
+
+		const result = readGroupActivity('pr-1', tmpDir);
+		expect(result?.last_activity).toBe('2026-05-05T10:00:05.000Z');
+		expect(result?.recent_actions).toHaveLength(2);
+		expect(result?.recent_actions[0]?.message).toBe('Running tests');
+		expect(result?.recent_actions[1]?.message).toBe('Reading src/types.ts');
+	});
+
+	it('caps at 20 entries', () => {
+		for (let i = 0; i < 25; i++) {
+			appendToolActivity(
+				'pr-1',
+				`Action ${i}`,
+				`2026-05-05T10:00:${String(i).padStart(2, '0')}.000Z`,
+				tmpDir,
+			);
+		}
+
+		const result = readGroupActivity('pr-1', tmpDir);
+		expect(result?.recent_actions).toHaveLength(20);
+		expect(result?.recent_actions[0]?.message).toBe('Action 24');
 	});
 });

--- a/src/status-manager.ts
+++ b/src/status-manager.ts
@@ -1,6 +1,12 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import type { GitBranchState, GroupStatus, GroupStep, ReconcileCorrection } from './types.js';
+import type {
+	GitBranchState,
+	GroupActivity,
+	GroupStatus,
+	GroupStep,
+	ReconcileCorrection,
+} from './types.js';
 import { assertValidSlug } from './validation.js';
 
 const VALID_STEPS: readonly GroupStep[] = [
@@ -72,6 +78,74 @@ export function writeGroupStatus(groupSlug: string, data: GroupStatus, baseDir?:
 	const tmpPath = `${filePath}.tmp`;
 	fs.writeFileSync(tmpPath, `${JSON.stringify(data, null, '\t')}\n`);
 	fs.renameSync(tmpPath, filePath);
+}
+
+// --- Activity file CRUD ---
+
+const MAX_RECENT_ACTIONS = 20;
+
+export function getGroupActivityPath(groupSlug: string, baseDir?: string): string {
+	return path.resolve(baseDir ?? '.', '.orchestrator/status', `${groupSlug}.activity.json`);
+}
+
+export function writeGroupActivity(groupSlug: string, data: GroupActivity, baseDir?: string): void {
+	assertValidSlug(groupSlug);
+	const filePath = getGroupActivityPath(groupSlug, baseDir);
+	const dir = path.dirname(filePath);
+	fs.mkdirSync(dir, { recursive: true });
+
+	const capped: GroupActivity = {
+		...data,
+		recent_actions: data.recent_actions.slice(0, MAX_RECENT_ACTIONS),
+	};
+
+	const tmpPath = `${filePath}.tmp`;
+	fs.writeFileSync(tmpPath, `${JSON.stringify(capped, null, '\t')}\n`);
+	fs.renameSync(tmpPath, filePath);
+}
+
+export function readGroupActivity(groupSlug: string, baseDir?: string): GroupActivity | null {
+	assertValidSlug(groupSlug);
+	const filePath = getGroupActivityPath(groupSlug, baseDir);
+
+	if (!fs.existsSync(filePath)) {
+		return null;
+	}
+
+	try {
+		const content = fs.readFileSync(filePath, 'utf-8');
+		const parsed: unknown = JSON.parse(content);
+		if (
+			typeof parsed === 'object' &&
+			parsed !== null &&
+			typeof (parsed as Record<string, unknown>).last_activity === 'string' &&
+			Array.isArray((parsed as Record<string, unknown>).recent_actions)
+		) {
+			return parsed as GroupActivity;
+		}
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+export function appendToolActivity(
+	groupSlug: string,
+	message: string,
+	nowIso: string,
+	baseDir?: string,
+): void {
+	const existing = readGroupActivity(groupSlug, baseDir);
+	const recentActions = existing?.recent_actions ?? [];
+
+	writeGroupActivity(
+		groupSlug,
+		{
+			last_activity: nowIso,
+			recent_actions: [{ timestamp: nowIso, message }, ...recentActions],
+		},
+		baseDir,
+	);
 }
 
 // --- Context file CRUD ---
@@ -146,7 +220,9 @@ export function reconcile(
 		return [];
 	}
 
-	const files = fs.readdirSync(statusDir).filter((f) => f.endsWith('.json'));
+	const files = fs
+		.readdirSync(statusDir)
+		.filter((f) => f.endsWith('.json') && !f.endsWith('.activity.json'));
 	const corrections: ReconcileCorrection[] = [];
 	const branchSet = new Set(gitState.branches);
 

--- a/src/status-manager.ts
+++ b/src/status-manager.ts
@@ -123,12 +123,21 @@ export function readGroupActivity(groupSlug: string, baseDir?: string): GroupAct
 		) {
 			return parsed as GroupActivity;
 		}
+		process.stderr.write(
+			`[status-manager] skipping malformed activity file ${groupSlug}.activity.json\n`,
+		);
 		return null;
-	} catch {
+	} catch (err: unknown) {
+		if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+		const detail = err instanceof Error ? err.message : String(err);
+		process.stderr.write(`[status-manager] failed to read activity for ${groupSlug}: ${detail}\n`);
 		return null;
 	}
 }
 
+// Note: appendToolActivity uses a read-then-write pattern that is not atomic.
+// Concurrent workers on the same slug may lose writes (TOCTOU race).
+// This is acceptable because activity data is cosmetic (TUI display only).
 export function appendToolActivity(
 	groupSlug: string,
 	message: string,

--- a/src/tui/Dashboard.test.tsx
+++ b/src/tui/Dashboard.test.tsx
@@ -330,6 +330,55 @@ describe('LogTailView', () => {
 			fs.rmSync(tmpDir, { recursive: true, force: true });
 		}
 	});
+
+	it('prefers .readable.log over raw .log files', async () => {
+		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'logtail-readable-'));
+		const groupSlug = 'pr-readable';
+		const logDir = path.join(tmpDir, '.orchestrator', 'logs', groupSlug);
+		fs.mkdirSync(logDir, { recursive: true });
+		fs.writeFileSync(path.join(logDir, '10.log'), '{"type":"assistant","message":"raw ndjson"}\n');
+		fs.writeFileSync(
+			path.join(logDir, '10.readable.log'),
+			'Working on implementation\n[tool] Read src/types.ts\n[result] Done\n',
+		);
+
+		try {
+			const { lastFrame } = render(
+				React.createElement(LogTailView, { groupSlug, baseDir: tmpDir }),
+			);
+			await act(async () => {
+				await new Promise((r) => setTimeout(r, 50));
+			});
+			const frame = lastFrame();
+			expect(frame).toContain('Working on implementation');
+			expect(frame).toContain('[tool] Read src/types.ts');
+			expect(frame).not.toContain('raw ndjson');
+		} finally {
+			fs.rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+
+	it('falls back to .log when no .readable.log exists', async () => {
+		const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'logtail-fallback-'));
+		const groupSlug = 'pr-fallback';
+		const logDir = path.join(tmpDir, '.orchestrator', 'logs', groupSlug);
+		fs.mkdirSync(logDir, { recursive: true });
+		fs.writeFileSync(path.join(logDir, '10.log'), 'raw line one\nraw line two\n');
+
+		try {
+			const { lastFrame } = render(
+				React.createElement(LogTailView, { groupSlug, baseDir: tmpDir }),
+			);
+			await act(async () => {
+				await new Promise((r) => setTimeout(r, 50));
+			});
+			const frame = lastFrame();
+			expect(frame).toContain('raw line one');
+			expect(frame).toContain('raw line two');
+		} finally {
+			fs.rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
 });
 
 describe('Sidebar', () => {

--- a/src/tui/Dashboard.test.tsx
+++ b/src/tui/Dashboard.test.tsx
@@ -130,6 +130,33 @@ describe('PRGroupsPanel', () => {
 		);
 		expect(lastFrame()).toContain('\u2699');
 	});
+
+	it('shows elapsed time from stepLabels prop', () => {
+		const groups = [makeGroup({ pr_group: 'pr-5', step: 'verifying' })];
+		const stepLabels = new Map([['pr-5', 'verifying (2m 34s)']]);
+		const { lastFrame } = render(
+			React.createElement(PRGroupsPanel, { groups, active: true, selectedIndex: 0, stepLabels }),
+		);
+		expect(lastFrame()).toContain('verifying (2m 34s)');
+	});
+
+	it('shows stale warning from stepLabels prop', () => {
+		const groups = [makeGroup({ pr_group: 'pr-5', step: 'coding' })];
+		const stepLabels = new Map([['pr-5', 'coding (3m 0s) \u26A0 no activity']]);
+		const { lastFrame } = render(
+			React.createElement(PRGroupsPanel, { groups, active: true, selectedIndex: 0, stepLabels }),
+		);
+		expect(lastFrame()).toContain('\u26A0 no activity');
+	});
+
+	it('falls back to step name when no stepLabels provided', () => {
+		const groups = [makeGroup({ pr_group: 'pr-5', step: 'coding' })];
+		const { lastFrame } = render(
+			React.createElement(PRGroupsPanel, { groups, active: true, selectedIndex: 0 }),
+		);
+		// Should still render without error — just no elapsed
+		expect(lastFrame()).toContain('pr-5');
+	});
 });
 
 describe('IssuesPanel', () => {

--- a/src/tui/Dashboard.tsx
+++ b/src/tui/Dashboard.tsx
@@ -31,7 +31,7 @@ export function Dashboard({
 	onQuit,
 }: DashboardProps): ReactNode {
 	const { width, height } = useScreenSize();
-	const { groups, activity } = useStatusPoller(baseDir, pollInterval);
+	const { groups, activity, stepLabels } = useStatusPoller(baseDir, pollInterval);
 
 	const notifConfig = config?.notifications ?? DEFAULT_CONFIG.notifications;
 	useNotifications(groups, notifConfig);
@@ -78,6 +78,7 @@ export function Dashboard({
 							selectedGroup={selectedGroup}
 							selectedIssueIndex={selectedIssueIndex}
 							activity={activity}
+							stepLabels={stepLabels}
 						/>
 					</Box>
 				)}

--- a/src/tui/LogTailView.tsx
+++ b/src/tui/LogTailView.tsx
@@ -96,15 +96,16 @@ interface LogReadResult {
 async function readLatestLogLines(logDir: string, maxLines: number): Promise<LogReadResult> {
 	try {
 		const entries = await fs.promises.readdir(logDir);
-		const files = entries
-			.filter((f) => f.endsWith('.log'))
-			.sort()
-			.reverse();
+		const allLogs = entries.filter((f) => f.endsWith('.log'));
 
-		if (files.length === 0) return { lines: [] };
+		if (allLogs.length === 0) return { lines: [] };
 
-		const latestLog = path.join(logDir, files[0] as string);
-		const content = await fs.promises.readFile(latestLog, 'utf-8');
+		// Prefer .readable.log files over raw .log files
+		const readableLogs = allLogs.filter((f) => f.endsWith('.readable.log'));
+		const targetFiles = readableLogs.length > 0 ? readableLogs : allLogs;
+		const latest = targetFiles.sort().reverse()[0] as string;
+
+		const content = await fs.promises.readFile(path.join(logDir, latest), 'utf-8');
 		return { lines: content.split('\n').filter(Boolean).slice(-maxLines) };
 	} catch (err: unknown) {
 		if ((err as NodeJS.ErrnoException).code === 'ENOENT') return { lines: [] };

--- a/src/tui/LogTailView.tsx
+++ b/src/tui/LogTailView.tsx
@@ -103,7 +103,12 @@ async function readLatestLogLines(logDir: string, maxLines: number): Promise<Log
 		// Prefer .readable.log files over raw .log files
 		const readableLogs = allLogs.filter((f) => f.endsWith('.readable.log'));
 		const targetFiles = readableLogs.length > 0 ? readableLogs : allLogs;
-		const latest = targetFiles.sort().reverse()[0] as string;
+		const latest = targetFiles.sort((a, b) => {
+			const numA = parseInt(a, 10);
+			const numB = parseInt(b, 10);
+			if (!Number.isNaN(numA) && !Number.isNaN(numB)) return numB - numA;
+			return b.localeCompare(a);
+		})[0] as string;
 
 		const content = await fs.promises.readFile(path.join(logDir, latest), 'utf-8');
 		return { lines: content.split('\n').filter(Boolean).slice(-maxLines) };

--- a/src/tui/PRGroupsPanel.tsx
+++ b/src/tui/PRGroupsPanel.tsx
@@ -8,9 +8,15 @@ interface PRGroupsPanelProps {
 	readonly groups: readonly GroupStatus[];
 	readonly active: boolean;
 	readonly selectedIndex: number;
+	readonly stepLabels?: ReadonlyMap<string, string>;
 }
 
-export function PRGroupsPanel({ groups, active, selectedIndex }: PRGroupsPanelProps): ReactNode {
+export function PRGroupsPanel({
+	groups,
+	active,
+	selectedIndex,
+	stepLabels,
+}: PRGroupsPanelProps): ReactNode {
 	if (groups.length === 0) {
 		return (
 			<Panel title="PR Groups" active={active}>
@@ -36,6 +42,8 @@ export function PRGroupsPanel({ groups, active, selectedIndex }: PRGroupsPanelPr
 				const total = group.issues_completed.length + group.issues_remaining.length;
 				const done = group.issues_completed.length;
 
+				const label = stepLabels?.get(group.pr_group);
+
 				return (
 					<Box key={group.pr_group} marginLeft={1}>
 						<Text
@@ -44,6 +52,7 @@ export function PRGroupsPanel({ groups, active, selectedIndex }: PRGroupsPanelPr
 						>
 							{icon} {group.pr_group} ({done}/{total})
 						</Text>
+						{label ? <Text dimColor> {label}</Text> : null}
 					</Box>
 				);
 			})}

--- a/src/tui/Sidebar.tsx
+++ b/src/tui/Sidebar.tsx
@@ -13,6 +13,7 @@ interface SidebarProps {
 	readonly selectedGroup: GroupStatus | null;
 	readonly selectedIssueIndex: number;
 	readonly activity: readonly ActivityEvent[];
+	readonly stepLabels?: ReadonlyMap<string, string>;
 }
 
 export function Sidebar({
@@ -22,6 +23,7 @@ export function Sidebar({
 	selectedGroup,
 	selectedIssueIndex,
 	activity,
+	stepLabels,
 }: SidebarProps): ReactNode {
 	return (
 		<Box flexDirection="column" flexGrow={1}>
@@ -29,6 +31,7 @@ export function Sidebar({
 				groups={groups}
 				active={activePanel === 0}
 				selectedIndex={selectedGroupIndex}
+				stepLabels={stepLabels}
 			/>
 			<IssuesPanel
 				group={selectedGroup}

--- a/src/tui/observability.test.ts
+++ b/src/tui/observability.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from 'vitest';
+import type { GroupStatus } from '../types.js';
+import {
+	formatElapsed,
+	formatStepLabel,
+	isStale,
+	parseToolUseActivity,
+	trackStepStarts,
+} from './observability.js';
+
+describe('formatElapsed', () => {
+	it('returns seconds only when under 1 minute', () => {
+		const start = '2026-05-05T10:00:00.000Z';
+		const now = '2026-05-05T10:00:45.000Z';
+		expect(formatElapsed(start, now)).toBe('45s');
+	});
+
+	it('returns minutes and seconds', () => {
+		const start = '2026-05-05T10:00:00.000Z';
+		const now = '2026-05-05T10:02:34.000Z';
+		expect(formatElapsed(start, now)).toBe('2m 34s');
+	});
+
+	it('returns hours, minutes, seconds for long durations', () => {
+		const start = '2026-05-05T10:00:00.000Z';
+		const now = '2026-05-05T11:05:12.000Z';
+		expect(formatElapsed(start, now)).toBe('1h 5m 12s');
+	});
+
+	it('returns 0s when start equals now', () => {
+		const t = '2026-05-05T10:00:00.000Z';
+		expect(formatElapsed(t, t)).toBe('0s');
+	});
+
+	it('clamps to 0s when start is in the future (clock skew)', () => {
+		const start = '2026-05-05T10:01:00.000Z';
+		const now = '2026-05-05T10:00:00.000Z';
+		expect(formatElapsed(start, now)).toBe('0s');
+	});
+
+	it('floors partial seconds', () => {
+		const start = '2026-05-05T10:00:00.000Z';
+		const now = '2026-05-05T10:00:02.999Z';
+		expect(formatElapsed(start, now)).toBe('2s');
+	});
+});
+
+const STALE_THRESHOLD = 90_000; // 90 seconds
+
+describe('isStale', () => {
+	it('returns false when activity is recent', () => {
+		const lastActivity = '2026-05-05T10:00:00.000Z';
+		const now = '2026-05-05T10:01:00.000Z'; // 60s ago
+		expect(isStale(lastActivity, now, STALE_THRESHOLD)).toBe(false);
+	});
+
+	it('returns true when no activity for threshold duration', () => {
+		const lastActivity = '2026-05-05T10:00:00.000Z';
+		const now = '2026-05-05T10:01:30.000Z'; // exactly 90s
+		expect(isStale(lastActivity, now, STALE_THRESHOLD)).toBe(true);
+	});
+
+	it('returns true when well past threshold', () => {
+		const lastActivity = '2026-05-05T10:00:00.000Z';
+		const now = '2026-05-05T10:05:00.000Z'; // 5 minutes
+		expect(isStale(lastActivity, now, STALE_THRESHOLD)).toBe(true);
+	});
+
+	it('returns false when just under threshold', () => {
+		const lastActivity = '2026-05-05T10:00:00.000Z';
+		const now = '2026-05-05T10:01:29.999Z'; // 89.999s
+		expect(isStale(lastActivity, now, STALE_THRESHOLD)).toBe(false);
+	});
+
+	it('returns false when activity resumes (recent timestamp)', () => {
+		const lastActivity = '2026-05-05T10:05:00.000Z'; // just updated
+		const now = '2026-05-05T10:05:01.000Z';
+		expect(isStale(lastActivity, now, STALE_THRESHOLD)).toBe(false);
+	});
+});
+
+describe('formatStepLabel', () => {
+	it('returns step name with elapsed time', () => {
+		const result = formatStepLabel(
+			'verifying',
+			'2026-05-05T10:00:00.000Z',
+			'2026-05-05T10:02:30.000Z',
+			'2026-05-05T10:02:34.000Z',
+			STALE_THRESHOLD,
+		);
+		expect(result).toBe('verifying (2m 34s)');
+	});
+
+	it('returns step name only when no start time', () => {
+		const result = formatStepLabel(
+			'coding',
+			null,
+			null,
+			'2026-05-05T10:00:00.000Z',
+			STALE_THRESHOLD,
+		);
+		expect(result).toBe('coding');
+	});
+
+	it('appends stale warning when no activity past threshold', () => {
+		const result = formatStepLabel(
+			'coding',
+			'2026-05-05T10:00:00.000Z',
+			'2026-05-05T10:00:10.000Z', // last activity 2m ago
+			'2026-05-05T10:02:10.000Z',
+			STALE_THRESHOLD,
+		);
+		expect(result).toBe('coding (2m 10s) \u26A0 no activity');
+	});
+
+	it('no stale warning when activity is recent', () => {
+		const result = formatStepLabel(
+			'coding',
+			'2026-05-05T10:00:00.000Z',
+			'2026-05-05T10:02:00.000Z', // activity 10s ago
+			'2026-05-05T10:02:10.000Z',
+			STALE_THRESHOLD,
+		);
+		expect(result).toBe('coding (2m 10s)');
+	});
+
+	it('uses stepStart for stale check when no lastActivity', () => {
+		const result = formatStepLabel(
+			'verifying',
+			'2026-05-05T10:00:00.000Z',
+			null, // no activity callback yet
+			'2026-05-05T10:02:00.000Z',
+			STALE_THRESHOLD,
+		);
+		// 2 minutes > 90s threshold, stale
+		expect(result).toBe('verifying (2m 0s) \u26A0 no activity');
+	});
+
+	it('idle step returns just step name regardless', () => {
+		const result = formatStepLabel(
+			'idle',
+			'2026-05-05T10:00:00.000Z',
+			null,
+			'2026-05-05T10:05:00.000Z',
+			STALE_THRESHOLD,
+		);
+		expect(result).toBe('idle');
+	});
+});
+
+function makeGroup(overrides?: Partial<GroupStatus>): GroupStatus {
+	return {
+		pr_group: 'pr-1',
+		branch: 'feat/test',
+		current_issue: 1,
+		step: 'coding',
+		step_result: '',
+		issues_completed: [],
+		issues_remaining: [1, 2],
+		last_updated: '2026-05-05T10:00:00.000Z',
+		...overrides,
+	};
+}
+
+describe('trackStepStarts', () => {
+	it('records start time for new groups', () => {
+		const groups = [makeGroup({ pr_group: 'pr-1', step: 'coding' })];
+		const result = trackStepStarts(new Map(), groups, '2026-05-05T10:00:00.000Z');
+
+		expect(result.get('pr-1')).toBe('2026-05-05T10:00:00.000Z');
+	});
+
+	it('updates start time on step change', () => {
+		const prev = new Map([['pr-1', '2026-05-05T09:00:00.000Z']]);
+		const groups = [makeGroup({ pr_group: 'pr-1', step: 'verifying' })];
+		// prev groups had step 'coding', now 'verifying' — but trackStepStarts needs prev step info
+		// We need to pass prev groups too, or track step alongside timestamp
+		const result = trackStepStarts(prev, groups, '2026-05-05T10:05:00.000Z', [
+			makeGroup({ pr_group: 'pr-1', step: 'coding' }),
+		]);
+
+		expect(result.get('pr-1')).toBe('2026-05-05T10:05:00.000Z');
+	});
+
+	it('preserves start time when step unchanged', () => {
+		const prev = new Map([['pr-1', '2026-05-05T09:00:00.000Z']]);
+		const groups = [makeGroup({ pr_group: 'pr-1', step: 'coding' })];
+		const result = trackStepStarts(prev, groups, '2026-05-05T10:05:00.000Z', [
+			makeGroup({ pr_group: 'pr-1', step: 'coding' }),
+		]);
+
+		expect(result.get('pr-1')).toBe('2026-05-05T09:00:00.000Z');
+	});
+
+	it('removes entries for groups no longer present', () => {
+		const prev = new Map([
+			['pr-1', '2026-05-05T09:00:00.000Z'],
+			['pr-2', '2026-05-05T09:00:00.000Z'],
+		]);
+		const groups = [makeGroup({ pr_group: 'pr-1', step: 'coding' })];
+		const result = trackStepStarts(prev, groups, '2026-05-05T10:00:00.000Z', [
+			makeGroup({ pr_group: 'pr-1', step: 'coding' }),
+		]);
+
+		expect(result.has('pr-2')).toBe(false);
+		expect(result.size).toBe(1);
+	});
+});
+
+describe('parseToolUseActivity', () => {
+	it('extracts Read tool with file path', () => {
+		const line = '{"type":"tool_use","name":"Read","input":{"file_path":"src/types.ts"}}';
+		expect(parseToolUseActivity(line)).toBe('Reading src/types.ts');
+	});
+
+	it('extracts Edit tool with file path', () => {
+		const line = '{"type":"tool_use","name":"Edit","input":{"file_path":"src/foo.ts"}}';
+		expect(parseToolUseActivity(line)).toBe('Editing src/foo.ts');
+	});
+
+	it('extracts Write tool with file path', () => {
+		const line = '{"type":"tool_use","name":"Write","input":{"file_path":"src/new.ts"}}';
+		expect(parseToolUseActivity(line)).toBe('Writing src/new.ts');
+	});
+
+	it('extracts Bash tool with command', () => {
+		const line = '{"type":"tool_use","name":"Bash","input":{"command":"pnpm run test"}}';
+		expect(parseToolUseActivity(line)).toBe('Running pnpm run test');
+	});
+
+	it('truncates long Bash commands', () => {
+		const longCmd = 'a'.repeat(100);
+		const line = JSON.stringify({ type: 'tool_use', name: 'Bash', input: { command: longCmd } });
+		const result = parseToolUseActivity(line);
+		expect(result).not.toBeNull();
+		expect(result?.length).toBeLessThanOrEqual(80);
+	});
+
+	it('extracts Grep tool with pattern', () => {
+		const line = '{"type":"tool_use","name":"Grep","input":{"pattern":"TODO"}}';
+		expect(parseToolUseActivity(line)).toBe('Grep TODO');
+	});
+
+	it('returns tool name for unknown input shape', () => {
+		const line = '{"type":"tool_use","name":"WebSearch","input":{"query":"something"}}';
+		expect(parseToolUseActivity(line)).toBe('WebSearch');
+	});
+
+	it('returns null for non-tool_use types', () => {
+		expect(parseToolUseActivity('{"type":"assistant","message":"hello"}')).toBeNull();
+		expect(parseToolUseActivity('{"type":"result","result":"done"}')).toBeNull();
+	});
+
+	it('returns null for invalid JSON', () => {
+		expect(parseToolUseActivity('not json')).toBeNull();
+	});
+});

--- a/src/tui/observability.test.ts
+++ b/src/tui/observability.test.ts
@@ -254,4 +254,9 @@ describe('parseToolUseActivity', () => {
 	it('returns null for invalid JSON', () => {
 		expect(parseToolUseActivity('not json')).toBeNull();
 	});
+
+	it('returns null when tool name is missing', () => {
+		const line = '{"type":"tool_use","input":{"file_path":"src/foo.ts"}}';
+		expect(parseToolUseActivity(line)).toBeNull();
+	});
 });

--- a/src/tui/observability.ts
+++ b/src/tui/observability.ts
@@ -89,6 +89,7 @@ export function parseToolUseActivity(line: string): string | null {
 	if (obj.type !== 'tool_use') return null;
 
 	const name = String(obj.name ?? '');
+	if (!name) return null;
 	const input = obj.input as Record<string, unknown> | undefined;
 
 	if (input) {

--- a/src/tui/observability.ts
+++ b/src/tui/observability.ts
@@ -1,0 +1,110 @@
+/**
+ * Pure observability helpers for TUI dashboard.
+ * Elapsed time formatting and stale detection — no TUI dependencies.
+ */
+
+import type { GroupStatus } from '../types.js';
+
+export function formatElapsed(startIso: string, nowIso: string): string {
+	const diffMs = Math.max(0, new Date(nowIso).getTime() - new Date(startIso).getTime());
+	const totalSeconds = Math.floor(diffMs / 1000);
+
+	const hours = Math.floor(totalSeconds / 3600);
+	const minutes = Math.floor((totalSeconds % 3600) / 60);
+	const seconds = totalSeconds % 60;
+
+	if (hours > 0) return `${hours}h ${minutes}m ${seconds}s`;
+	if (minutes > 0) return `${minutes}m ${seconds}s`;
+	return `${seconds}s`;
+}
+
+export function isStale(lastActivityIso: string, nowIso: string, thresholdMs: number): boolean {
+	const elapsed = new Date(nowIso).getTime() - new Date(lastActivityIso).getTime();
+	return elapsed >= thresholdMs;
+}
+
+// Steps where elapsed time and stale detection are not meaningful.
+// pr-creating/pr-reviewing intentionally excluded — we want stale detection there.
+const TERMINAL_STEPS = new Set(['idle', 'awaiting-merge']);
+
+export function formatStepLabel(
+	step: string,
+	stepStartIso: string | null,
+	lastActivityIso: string | null,
+	nowIso: string,
+	staleThresholdMs: number,
+): string {
+	if (!stepStartIso || TERMINAL_STEPS.has(step)) return step;
+
+	const elapsed = formatElapsed(stepStartIso, nowIso);
+	const activityRef = lastActivityIso ?? stepStartIso;
+	const stale = isStale(activityRef, nowIso, staleThresholdMs);
+
+	return stale ? `${step} (${elapsed}) \u26A0 no activity` : `${step} (${elapsed})`;
+}
+
+export function trackStepStarts(
+	prevStarts: ReadonlyMap<string, string>,
+	nextGroups: readonly GroupStatus[],
+	nowIso: string,
+	prevGroups?: readonly GroupStatus[],
+): Map<string, string> {
+	const prevStepMap = new Map((prevGroups ?? []).map((g) => [g.pr_group, g.step]));
+	const result = new Map<string, string>();
+
+	for (const group of nextGroups) {
+		const prevStart = prevStarts.get(group.pr_group);
+		const prevStep = prevStepMap.get(group.pr_group);
+
+		if (!prevStart || prevStep !== group.step) {
+			result.set(group.pr_group, nowIso);
+		} else {
+			result.set(group.pr_group, prevStart);
+		}
+	}
+
+	return result;
+}
+
+const ACTIVITY_MAX_LEN = 80;
+
+const TOOL_VERBS: ReadonlyMap<string, string> = new Map([
+	['Read', 'Reading'],
+	['Edit', 'Editing'],
+	['Write', 'Writing'],
+	['Bash', 'Running'],
+]);
+
+export function parseToolUseActivity(line: string): string | null {
+	const trimmed = line.trim();
+	if (!trimmed) return null;
+
+	let obj: Record<string, unknown>;
+	try {
+		obj = JSON.parse(trimmed) as Record<string, unknown>;
+	} catch {
+		return null;
+	}
+
+	if (obj.type !== 'tool_use') return null;
+
+	const name = String(obj.name ?? '');
+	const input = obj.input as Record<string, unknown> | undefined;
+
+	if (input) {
+		if (typeof input.file_path === 'string') {
+			const verb = TOOL_VERBS.get(name) ?? name;
+			return `${verb} ${input.file_path}`;
+		}
+		if (typeof input.command === 'string') {
+			const verb = TOOL_VERBS.get(name) ?? name;
+			const full = `${verb} ${input.command}`;
+			return full.length > ACTIVITY_MAX_LEN ? `${full.slice(0, ACTIVITY_MAX_LEN - 1)}\u2026` : full;
+		}
+		if (typeof input.pattern === 'string') {
+			return `${name} ${input.pattern}`;
+		}
+	}
+
+	return name;
+}

--- a/src/tui/use-status-poller.ts
+++ b/src/tui/use-status-poller.ts
@@ -1,15 +1,20 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { useEffect, useRef, useState } from 'react';
-import { readGroupStatus } from '../status-manager.js';
-import type { GroupStatus } from '../types.js';
+import { readGroupActivity, readGroupStatus } from '../status-manager.js';
+import type { GroupActivity, GroupStatus } from '../types.js';
+import { formatStepLabel, trackStepStarts } from './observability.js';
 import type { ActivityEvent } from './types.js';
+
+const STALE_THRESHOLD_MS = 90_000;
 
 async function listGroupSlugs(baseDir: string): Promise<readonly string[]> {
 	const statusDir = path.resolve(baseDir, '.orchestrator/status');
 	try {
 		const entries = await fs.promises.readdir(statusDir);
-		return entries.filter((f) => f.endsWith('.json')).map((f) => f.replace(/\.json$/, ''));
+		return entries
+			.filter((f) => f.endsWith('.json') && !f.endsWith('.activity.json'))
+			.map((f) => f.replace(/\.json$/, ''));
 	} catch (err: unknown) {
 		if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
 		throw err;
@@ -49,12 +54,16 @@ export function deriveActivity(
 export interface StatusPollerResult {
 	readonly groups: readonly GroupStatus[];
 	readonly activity: readonly ActivityEvent[];
+	readonly stepLabels: ReadonlyMap<string, string>;
 }
 
 export function useStatusPoller(baseDir: string, intervalMs = 2000): StatusPollerResult {
 	const [groups, setGroups] = useState<readonly GroupStatus[]>([]);
 	const [activity, setActivity] = useState<readonly ActivityEvent[]>([]);
+	const [stepLabels, setStepLabels] = useState<ReadonlyMap<string, string>>(new Map());
 	const prevGroupsRef = useRef<readonly GroupStatus[]>([]);
+	const stepStartTimesRef = useRef<ReadonlyMap<string, string>>(new Map());
+	const prevToolActionsRef = useRef<ReadonlySet<string>>(new Set());
 	const nextIdRef = useRef(1);
 
 	useEffect(() => {
@@ -62,6 +71,8 @@ export function useStatusPoller(baseDir: string, intervalMs = 2000): StatusPolle
 			try {
 				const slugs = await listGroupSlugs(baseDir);
 				const entries: GroupStatus[] = [];
+				const lastActivityMap = new Map<string, string>();
+				const activityCache = new Map<string, GroupActivity | null>();
 
 				for (const slug of slugs) {
 					try {
@@ -71,17 +82,74 @@ export function useStatusPoller(baseDir: string, intervalMs = 2000): StatusPolle
 						const detail = slugErr instanceof Error ? slugErr.message : String(slugErr);
 						process.stderr.write(`[status-poller] skipping ${slug}: ${detail}\n`);
 					}
+
+					try {
+						const groupActivity = readGroupActivity(slug, baseDir);
+						activityCache.set(slug, groupActivity);
+						if (groupActivity?.last_activity) {
+							lastActivityMap.set(slug, groupActivity.last_activity);
+						}
+					} catch {
+						activityCache.set(slug, null);
+					}
 				}
 
-				const now = new Date().toISOString().slice(11, 16);
+				const nowIso = new Date().toISOString();
+				const now = nowIso.slice(11, 16);
 				const result = deriveActivity(prevGroupsRef.current, entries, now, nextIdRef.current);
 				nextIdRef.current = result.nextId;
+
+				// Collect new tool actions from cached activity reads
+				const toolEvents: ActivityEvent[] = [];
+				const newSeenKeys = new Set<string>();
+				for (const slug of slugs) {
+					const groupActivity = activityCache.get(slug);
+					if (groupActivity) {
+						for (const action of groupActivity.recent_actions) {
+							if (!action.timestamp || !action.message) continue;
+							const key = `${slug}:${action.timestamp}:${action.message}`;
+							newSeenKeys.add(key);
+							if (!prevToolActionsRef.current.has(key)) {
+								toolEvents.push({
+									id: nextIdRef.current++,
+									timestamp: action.timestamp.slice(11, 16),
+									message: action.message,
+								});
+							}
+						}
+					}
+				}
+				prevToolActionsRef.current = newSeenKeys;
+
+				const newStepStarts = trackStepStarts(
+					stepStartTimesRef.current,
+					entries,
+					nowIso,
+					prevGroupsRef.current,
+				);
+				stepStartTimesRef.current = newStepStarts;
+
+				const labels = new Map<string, string>();
+				for (const group of entries) {
+					labels.set(
+						group.pr_group,
+						formatStepLabel(
+							group.step,
+							newStepStarts.get(group.pr_group) ?? null,
+							lastActivityMap.get(group.pr_group) ?? null,
+							nowIso,
+							STALE_THRESHOLD_MS,
+						),
+					);
+				}
+				setStepLabels(labels);
 
 				prevGroupsRef.current = entries;
 				setGroups(entries);
 
-				if (result.events.length > 0) {
-					setActivity((prev) => [...result.events, ...prev].slice(0, 50));
+				const allNewEvents = [...toolEvents, ...result.events];
+				if (allNewEvents.length > 0) {
+					setActivity((prev) => [...allNewEvents, ...prev].slice(0, 50));
 				}
 			} catch (err: unknown) {
 				const msg = err instanceof Error ? err.message : String(err);
@@ -94,5 +162,5 @@ export function useStatusPoller(baseDir: string, intervalMs = 2000): StatusPolle
 		return () => clearInterval(timer);
 	}, [baseDir, intervalMs]);
 
-	return { groups, activity };
+	return { groups, activity, stepLabels };
 }

--- a/src/tui/use-status-poller.ts
+++ b/src/tui/use-status-poller.ts
@@ -83,14 +83,10 @@ export function useStatusPoller(baseDir: string, intervalMs = 2000): StatusPolle
 						process.stderr.write(`[status-poller] skipping ${slug}: ${detail}\n`);
 					}
 
-					try {
-						const groupActivity = readGroupActivity(slug, baseDir);
-						activityCache.set(slug, groupActivity);
-						if (groupActivity?.last_activity) {
-							lastActivityMap.set(slug, groupActivity.last_activity);
-						}
-					} catch {
-						activityCache.set(slug, null);
+					const groupActivity = readGroupActivity(slug, baseDir);
+					activityCache.set(slug, groupActivity);
+					if (groupActivity?.last_activity) {
+						lastActivityMap.set(slug, groupActivity.last_activity);
 					}
 				}
 

--- a/src/tui/use-status-poller.ts
+++ b/src/tui/use-status-poller.ts
@@ -83,10 +83,18 @@ export function useStatusPoller(baseDir: string, intervalMs = 2000): StatusPolle
 						process.stderr.write(`[status-poller] skipping ${slug}: ${detail}\n`);
 					}
 
-					const groupActivity = readGroupActivity(slug, baseDir);
-					activityCache.set(slug, groupActivity);
-					if (groupActivity?.last_activity) {
-						lastActivityMap.set(slug, groupActivity.last_activity);
+					try {
+						const groupActivity = readGroupActivity(slug, baseDir);
+						activityCache.set(slug, groupActivity);
+						if (groupActivity?.last_activity) {
+							lastActivityMap.set(slug, groupActivity.last_activity);
+						}
+					} catch (slugErr: unknown) {
+						const detail = slugErr instanceof Error ? slugErr.message : String(slugErr);
+						process.stderr.write(
+							`[status-poller] failed to read activity for ${slug}: ${detail}\n`,
+						);
+						activityCache.set(slug, null);
 					}
 				}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,6 +101,16 @@ export interface GroupStatus {
 	readonly last_updated: string;
 }
 
+export interface ActivityAction {
+	readonly timestamp: string;
+	readonly message: string;
+}
+
+export interface GroupActivity {
+	readonly last_activity: string;
+	readonly recent_actions: readonly ActivityAction[];
+}
+
 export interface GitBranchState {
 	readonly branches: readonly string[];
 	readonly branchHasCommits: ReadonlyMap<string, boolean>;
@@ -185,6 +195,7 @@ export type NdjsonMessage = NdjsonSystemMessage | NdjsonAssistantMessage | Ndjso
 export type WorkerEvent =
 	| { readonly event: 'spawned' }
 	| { readonly event: 'message'; readonly data: NdjsonMessage }
+	| { readonly event: 'tool_activity'; readonly data: string }
 	| { readonly event: 'error'; readonly data: Error }
 	| { readonly event: 'exited'; readonly data: number };
 

--- a/src/worker-manager.test.ts
+++ b/src/worker-manager.test.ts
@@ -282,9 +282,14 @@ describe('formatReadableLine', () => {
 		expect(formatReadableLine('  ')).toBeNull();
 	});
 
-	it('returns null for tool_result type', () => {
+	it('returns null for non-error tool_result type', () => {
 		const line = '{"type":"tool_result","content":"some output"}';
 		expect(formatReadableLine(line)).toBeNull();
+	});
+
+	it('formats error tool_result with content', () => {
+		const line = '{"type":"tool_result","content":"Permission denied","is_error":true}';
+		expect(formatReadableLine(line)).toBe('[tool_result] ERROR: Permission denied');
 	});
 
 	it('skips assistant messages with empty text', () => {

--- a/src/worker-manager.test.ts
+++ b/src/worker-manager.test.ts
@@ -8,8 +8,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { NdjsonMessage, WorkerEvent } from './types.js';
 import {
 	buildPrompt,
+	formatReadableLine,
 	getLogDir,
 	getLogPath,
+	getReadableLogPath,
 	killWorker,
 	parseNdjsonLine,
 	spawnWorker,
@@ -85,6 +87,18 @@ describe('getLogPath', () => {
 	it('returns log file path for group and issue', () => {
 		const result = getLogPath('pr-1', '10', '/repo');
 		expect(result).toBe(path.resolve('/repo', '.orchestrator/logs/pr-1/10.log'));
+	});
+});
+
+describe('getReadableLogPath', () => {
+	it('returns .readable.log path for group and issue', () => {
+		const result = getReadableLogPath('pr-1', '10', '/repo');
+		expect(result).toBe(path.resolve('/repo', '.orchestrator/logs/pr-1/10.readable.log'));
+	});
+
+	it('defaults to cwd when no baseDir', () => {
+		const result = getReadableLogPath('pr-1', '10');
+		expect(result).toBe(path.resolve('.', '.orchestrator/logs/pr-1/10.readable.log'));
 	});
 });
 
@@ -168,6 +182,122 @@ describe('parseNdjsonLine', () => {
 			subtype: '',
 			session_id: '',
 		});
+	});
+});
+
+describe('formatReadableLine', () => {
+	it('extracts text from assistant message with string content', () => {
+		const line = '{"type":"assistant","message":"Working on implementation"}';
+		expect(formatReadableLine(line)).toBe('Working on implementation');
+	});
+
+	it('extracts text from assistant message with Claude protocol object', () => {
+		const line = JSON.stringify({
+			type: 'assistant',
+			message: {
+				id: 'msg_1',
+				content: [
+					{ type: 'text', text: 'Reading the file now' },
+					{ type: 'text', text: ' and checking types' },
+				],
+			},
+		});
+		expect(formatReadableLine(line)).toBe('Reading the file now and checking types');
+	});
+
+	it('formats tool_use with tool name and file path input', () => {
+		const line = JSON.stringify({
+			type: 'tool_use',
+			name: 'Read',
+			input: { file_path: 'src/types.ts' },
+		});
+		expect(formatReadableLine(line)).toBe('[tool] Read src/types.ts');
+	});
+
+	it('formats tool_use Edit with file path', () => {
+		const line = JSON.stringify({
+			type: 'tool_use',
+			name: 'Edit',
+			input: { file_path: 'src/foo.ts' },
+		});
+		expect(formatReadableLine(line)).toBe('[tool] Edit src/foo.ts');
+	});
+
+	it('formats tool_use Bash with command summary', () => {
+		const line = JSON.stringify({
+			type: 'tool_use',
+			name: 'Bash',
+			input: { command: 'git status' },
+		});
+		expect(formatReadableLine(line)).toBe('[tool] Bash: git status');
+	});
+
+	it('truncates long Bash commands', () => {
+		const longCmd = 'a'.repeat(200);
+		const line = JSON.stringify({
+			type: 'tool_use',
+			name: 'Bash',
+			input: { command: longCmd },
+		});
+		const result = formatReadableLine(line);
+		expect(result?.length).toBeLessThanOrEqual(120);
+		expect(result).toContain('…');
+	});
+
+	it('formats tool_use with just name when no recognizable input', () => {
+		const line = JSON.stringify({
+			type: 'tool_use',
+			name: 'WebSearch',
+			input: { query: 'something' },
+		});
+		expect(formatReadableLine(line)).toBe('[tool] WebSearch');
+	});
+
+	it('formats result message', () => {
+		const line = '{"type":"result","result":"Done","is_error":false}';
+		expect(formatReadableLine(line)).toBe('[result] Done');
+	});
+
+	it('formats error result message', () => {
+		const line = '{"type":"result","result":"Failed to complete","is_error":true}';
+		expect(formatReadableLine(line)).toBe('[result] ERROR: Failed to complete');
+	});
+
+	it('returns null for system messages', () => {
+		const line = '{"type":"system","subtype":"init","session_id":"abc"}';
+		expect(formatReadableLine(line)).toBeNull();
+	});
+
+	it('returns null for rate_limit_event', () => {
+		const line = '{"type":"rate_limit_event"}';
+		expect(formatReadableLine(line)).toBeNull();
+	});
+
+	it('returns null for invalid JSON', () => {
+		expect(formatReadableLine('not json')).toBeNull();
+	});
+
+	it('returns null for empty line', () => {
+		expect(formatReadableLine('')).toBeNull();
+		expect(formatReadableLine('  ')).toBeNull();
+	});
+
+	it('returns null for tool_result type', () => {
+		const line = '{"type":"tool_result","content":"some output"}';
+		expect(formatReadableLine(line)).toBeNull();
+	});
+
+	it('skips assistant messages with empty text', () => {
+		const line = '{"type":"assistant","message":""}';
+		expect(formatReadableLine(line)).toBeNull();
+	});
+
+	it('skips assistant protocol messages with no text content', () => {
+		const line = JSON.stringify({
+			type: 'assistant',
+			message: { id: 'msg_1', content: [{ type: 'tool_use', name: 'Read' }] },
+		});
+		expect(formatReadableLine(line)).toBeNull();
 	});
 });
 
@@ -396,6 +526,46 @@ describe('spawnWorker', () => {
 		spawnWorker('10', 'pr-1', tmpDir, () => {}, undefined, tmpDir);
 
 		expect(fs.existsSync(getLogDir('pr-1', tmpDir))).toBe(true);
+	});
+
+	it('writes readable log alongside raw log', async () => {
+		const proc = setupProc();
+
+		spawnWorker('10', 'pr-1', tmpDir, () => {}, undefined, tmpDir);
+
+		proc.stdout.write('{"type":"assistant","message":"Working on it"}\n');
+		proc.stdout.write('{"type":"tool_use","name":"Read","input":{"file_path":"src/types.ts"}}\n');
+		proc.stdout.write('{"type":"result","result":"Done","is_error":false}\n');
+		await new Promise((r) => setTimeout(r, 50));
+
+		proc.emit('close', 0);
+		await new Promise((r) => setTimeout(r, 50));
+
+		const readablePath = getReadableLogPath('pr-1', '10', tmpDir);
+		expect(fs.existsSync(readablePath)).toBe(true);
+		const content = fs.readFileSync(readablePath, 'utf-8');
+		expect(content).toContain('Working on it');
+		expect(content).toContain('[tool] Read src/types.ts');
+		expect(content).toContain('[result] Done');
+	});
+
+	it('does not write non-readable types to readable log', async () => {
+		const proc = setupProc();
+
+		spawnWorker('10', 'pr-1', tmpDir, () => {}, undefined, tmpDir);
+
+		proc.stdout.write('{"type":"system","subtype":"init","session_id":"s1"}\n');
+		proc.stdout.write('{"type":"rate_limit_event"}\n');
+		proc.stdout.write('{"type":"assistant","message":"hello"}\n');
+		await new Promise((r) => setTimeout(r, 50));
+
+		proc.emit('close', 0);
+		await new Promise((r) => setTimeout(r, 50));
+
+		const content = fs.readFileSync(getReadableLogPath('pr-1', '10', tmpDir), 'utf-8');
+		expect(content).not.toContain('system');
+		expect(content).not.toContain('rate_limit');
+		expect(content).toContain('hello');
 	});
 });
 

--- a/src/worker-manager.test.ts
+++ b/src/worker-manager.test.ts
@@ -505,6 +505,36 @@ describe('spawnWorker', () => {
 		);
 	});
 
+	it('emits tool_activity events for tool_use NDJSON lines', async () => {
+		const proc = setupProc();
+		const { events, cb } = collect();
+
+		spawnWorker('10', 'pr-1', tmpDir, cb, undefined, tmpDir);
+
+		proc.stdout.write('{"type":"tool_use","name":"Read","input":{"file_path":"src/types.ts"}}\n');
+		proc.stdout.write('{"type":"tool_use","name":"Bash","input":{"command":"pnpm run test"}}\n');
+		await new Promise((r) => setTimeout(r, 50));
+
+		const activityEvents = events.filter((e) => e.event === 'tool_activity');
+		expect(activityEvents).toHaveLength(2);
+		expect(activityEvents[0]?.data).toBe('Reading src/types.ts');
+		expect(activityEvents[1]?.data).toBe('Running pnpm run test');
+	});
+
+	it('does not emit tool_activity for non-tool_use types', async () => {
+		const proc = setupProc();
+		const { events, cb } = collect();
+
+		spawnWorker('10', 'pr-1', tmpDir, cb, undefined, tmpDir);
+
+		proc.stdout.write('{"type":"assistant","message":"working"}\n');
+		proc.stdout.write('{"type":"result","result":"done","is_error":false}\n');
+		await new Promise((r) => setTimeout(r, 50));
+
+		const activityEvents = events.filter((e) => e.event === 'tool_activity');
+		expect(activityEvents).toHaveLength(0);
+	});
+
 	it('skips invalid NDJSON lines without crashing', async () => {
 		const proc = setupProc();
 		const { events, cb } = collect();

--- a/src/worker-manager.ts
+++ b/src/worker-manager.ts
@@ -2,6 +2,7 @@ import { spawn } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as readline from 'node:readline';
+import { parseToolUseActivity } from './tui/observability.js';
 import type {
 	NdjsonAssistantMessage,
 	NdjsonMessage,
@@ -226,6 +227,11 @@ function spawnClaudeProcess(
 			const readable = formatReadableLine(line);
 			if (readable) {
 				readableLogStream.write(`${readable}\n`);
+			}
+
+			const activity = parseToolUseActivity(line);
+			if (activity) {
+				onEvent({ event: 'tool_activity', data: activity });
 			}
 
 			const msg = parseNdjsonLine(line);

--- a/src/worker-manager.ts
+++ b/src/worker-manager.ts
@@ -74,6 +74,12 @@ export function formatReadableLine(line: string): string | null {
 			return obj.is_error
 				? `[result] ERROR: ${String(obj.result ?? '')}`
 				: `[result] ${String(obj.result ?? '')}`;
+		case 'tool_result':
+			if (obj.is_error) {
+				const content = typeof obj.content === 'string' ? obj.content : String(obj.content ?? '');
+				return `[tool_result] ERROR: ${content}`;
+			}
+			return null;
 		default:
 			return null;
 	}

--- a/src/worker-manager.ts
+++ b/src/worker-manager.ts
@@ -29,6 +29,10 @@ export function getLogPath(groupSlug: string, issue: string, baseDir?: string): 
 	return path.resolve(baseDir ?? '.', '.orchestrator/logs', groupSlug, `${issue}.log`);
 }
 
+export function getReadableLogPath(groupSlug: string, issue: string, baseDir?: string): string {
+	return path.resolve(baseDir ?? '.', '.orchestrator/logs', groupSlug, `${issue}.readable.log`);
+}
+
 const VERBOSE_ONLY_TYPES = new Set(['user', 'rate_limit_event', 'tool_use', 'tool_result']);
 
 /** Returns true if line is valid JSON with a known verbose-mode type (safe to ignore silently). */
@@ -39,6 +43,79 @@ function isKnownNdjsonType(line: string): boolean {
 	} catch {
 		return false;
 	}
+}
+
+const READABLE_LINE_MAX = 120;
+
+/**
+ * Convert a raw NDJSON line into a human-readable log string.
+ * Returns null for types that should not appear in the readable log.
+ */
+export function formatReadableLine(line: string): string | null {
+	const trimmed = line.trim();
+	if (!trimmed) return null;
+
+	let obj: Record<string, unknown>;
+	try {
+		obj = JSON.parse(trimmed) as Record<string, unknown>;
+	} catch {
+		return null;
+	}
+
+	if (typeof obj !== 'object' || obj === null || typeof obj.type !== 'string') return null;
+
+	switch (obj.type) {
+		case 'assistant':
+			return formatAssistant(obj.message);
+		case 'tool_use':
+			return formatToolUse(obj.name as string, obj.input as Record<string, unknown> | undefined);
+		case 'result':
+			return obj.is_error
+				? `[result] ERROR: ${String(obj.result ?? '')}`
+				: `[result] ${String(obj.result ?? '')}`;
+		default:
+			return null;
+	}
+}
+
+function formatAssistant(message: unknown): string | null {
+	if (typeof message === 'string') {
+		return message || null;
+	}
+	if (typeof message === 'object' && message !== null) {
+		const msg = message as { content?: unknown[] };
+		if (Array.isArray(msg.content)) {
+			const texts = msg.content
+				.filter(
+					(block): block is { type: 'text'; text: string } =>
+						typeof block === 'object' &&
+						block !== null &&
+						(block as Record<string, unknown>).type === 'text' &&
+						typeof (block as Record<string, unknown>).text === 'string',
+				)
+				.map((block) => block.text);
+			const joined = texts.join('');
+			return joined || null;
+		}
+	}
+	return null;
+}
+
+function formatToolUse(name: string, input?: Record<string, unknown>): string {
+	if (input) {
+		if (typeof input.file_path === 'string') {
+			return `[tool] ${name} ${input.file_path}`;
+		}
+		if (typeof input.command === 'string') {
+			const cmd = input.command as string;
+			const summary = `[tool] ${name}: ${cmd}`;
+			if (summary.length > READABLE_LINE_MAX) {
+				return `${summary.slice(0, READABLE_LINE_MAX - 1)}…`;
+			}
+			return summary;
+		}
+	}
+	return `[tool] ${name}`;
 }
 
 export function parseNdjsonLine(line: string): NdjsonMessage | null {
@@ -102,10 +179,17 @@ function spawnClaudeProcess(
 	baseDir?: string,
 ): WorkerHandle {
 	const logPath = getLogPath(groupSlug, id, baseDir);
+	const readableLogPath = getReadableLogPath(groupSlug, id, baseDir);
 	fs.mkdirSync(path.dirname(logPath), { recursive: true });
 	const logStream = fs.createWriteStream(logPath, { flags: 'a' });
 	logStream.on('error', (err) => {
 		process.stderr.write(`[worker-manager] log write error for ${logPath}: ${err.message}\n`);
+	});
+	const readableLogStream = fs.createWriteStream(readableLogPath, { flags: 'a' });
+	readableLogStream.on('error', (err) => {
+		process.stderr.write(
+			`[worker-manager] readable log write error for ${readableLogPath}: ${err.message}\n`,
+		);
 	});
 
 	const proc = spawn('claude', ['-p', '--verbose', '--output-format', 'stream-json', prompt], {
@@ -130,6 +214,7 @@ function spawnClaudeProcess(
 		if (!logClosed) {
 			logClosed = true;
 			logStream.end();
+			readableLogStream.end();
 		}
 	};
 
@@ -137,6 +222,12 @@ function spawnClaudeProcess(
 		const rl = readline.createInterface({ input: proc.stdout });
 		rl.on('line', (line) => {
 			logStream.write(`${line}\n`);
+
+			const readable = formatReadableLine(line);
+			if (readable) {
+				readableLogStream.write(`${readable}\n`);
+			}
+
 			const msg = parseNdjsonLine(line);
 			if (msg) {
 				onEvent({ event: 'message', data: msg });


### PR DESCRIPTION
## Summary

Implements two related observability features for the TUI dashboard:

- **#41 — Human-readable worker logs from NDJSON stream**: Parse raw NDJSON output from Claude workers into human-friendly log lines. `tool_use` → `[tool] Read src/types.ts`, `assistant` → plain text, `result` → `[result] Done`. Written to `.readable.log` alongside raw logs. `LogTailView` prefers `.readable.log` over raw `.log` files.

- **#42 — Stuck detection + elapsed time + live activity in TUI**: Three observability additions:
  1. **Elapsed time per step** — PRGroupsPanel shows `verifying (2m 34s)` next to each group
  2. **Stale detection** — After 90s of no worker activity, displays `⚠ no activity` warning
  3. **Live worker activity in ActivityPanel** — Streams tool actions (e.g., "Reading src/types.ts", "Running pnpm run test") into the activity feed, derived from `tool_use` NDJSON events via file-based bridge

## Architecture

```
Worker NDJSON stream
  → worker-manager parses tool_use → emits tool_activity event
  → orchestrate.ts wrappers catch tool_activity → appendToolActivity()
  → writes .orchestrator/status/{slug}.activity.json
  → useStatusPoller reads activity files on each poll cycle
  → builds lastActivity map → formatStepLabel computes elapsed + stale
  → merges recent_actions into ActivityPanel events
  → PRGroupsPanel renders stepLabels with elapsed + stale warning
```

File-based bridge chosen for consistency with existing status file polling architecture, process boundary safety, and debuggability.

## Closes

- Closes #41
- Closes #42

## Changed Files

| File | Change |
|------|--------|
| `src/tui/observability.ts` | NEW — 5 pure functions (formatElapsed, isStale, formatStepLabel, trackStepStarts, parseToolUseActivity) |
| `src/tui/observability.test.ts` | NEW — 25 tests for pure observability functions |
| `src/worker-manager.ts` | `formatReadableLine` + `tool_activity` event emission |
| `src/worker-manager.test.ts` | Tests for readable log formatting + tool_activity events |
| `src/types.ts` | `tool_activity` WorkerEvent variant + `GroupActivity`/`ActivityAction` types |
| `src/status-manager.ts` | `writeGroupActivity`, `readGroupActivity`, `appendToolActivity` + reconcile filter |
| `src/status-manager.test.ts` | Tests for activity file CRUD + appendToolActivity |
| `src/orchestrate.ts` | `handleToolActivity` in spawn wrappers |
| `src/tui/use-status-poller.ts` | Activity file reading, stepStartTimes tracking, stepLabels computation |
| `src/tui/PRGroupsPanel.tsx` | `stepLabels` prop rendering elapsed + stale |
| `src/tui/Sidebar.tsx` | Pass stepLabels through |
| `src/tui/Dashboard.tsx` | Pass stepLabels from useStatusPoller |
| `src/tui/Dashboard.test.tsx` | Tests for stepLabels rendering in PRGroupsPanel |
| `src/tui/LogTailView.tsx` | Prefer `.readable.log` over raw `.log` |
| `docs/guide/first-run-fixes-pr-plan.md` | Updated plan status |

## Test Plan

- [x] `pnpm run test` — 588 tests pass
- [x] `pnpm run check` — Biome lint/format clean
- [x] `pnpm run build` — Build succeeds
- [ ] Manual: Run orchestrator with active workers, verify PRGroupsPanel shows elapsed time updating each poll
- [ ] Manual: Kill a worker process, wait 90s, verify `⚠ no activity` warning appears
- [ ] Manual: Resume worker activity, verify warning clears on next poll
- [ ] Manual: Verify ActivityPanel shows live tool actions (Reading, Editing, Running)
- [ ] Manual: Verify `.orchestrator/status/{slug}.activity.json` written during worker execution
- [ ] Manual: Verify `LogTailView` (press `l`) shows human-readable output, not raw NDJSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)