### PR TITLE
feat: configurable routing + pre-fetch issue content (#45, #46)

### DIFF
--- a/docs/guide/first-run-fixes-pr-plan.md
+++ b/docs/guide/first-run-fixes-pr-plan.md
@@ -6,7 +6,7 @@ tags:
   - first-run
   - dogfooding
 created: 2026-05-04
-updated: 2026-05-05
+updated: 2026-05-06
 status: active
 related:
   - "[Parent Epic: #38](https://github.com/aaronhsyong2/claude-orchestrator/issues/38)"
@@ -57,12 +57,13 @@ Logical grouping of issues from the first-run orchestrator fixes (#38) into PRs.
 ## PR 4: Configurable Routing + Pre-fetch + Constraints
 
 **Branch:** `feat/issue-45-46`
-**Status:** pending
+**PR:** #53
+**Status:** closed
 
 | Issue | Title | Status |
 |-------|-------|--------|
-| #45 | Remove /pick-up from workers, add configurable routing | Open |
-| #46 | Pre-fetch issue body + inject system prompt constraints | Open |
+| #45 | Remove /pick-up from workers, add configurable routing | Closed |
+| #46 | Pre-fetch issue body + inject system prompt constraints | Closed |
 
 ## PR 5: Resume CLI Command
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -105,6 +105,19 @@ describe('validateConfig', () => {
 	it('returns false for wrong field types', () => {
 		expect(validateConfig({ ...DEFAULT_CONFIG, max_concurrent_agents: 'three' })).toBe(false);
 	});
+
+	it('accepts config with optional routing field', () => {
+		const withRouting = {
+			...DEFAULT_CONFIG,
+			routing: { 'bug+ready-for-agent': '/diagnose' },
+		};
+		expect(validateConfig(withRouting)).toBe(true);
+	});
+
+	it('accepts config without routing field', () => {
+		const { routing: _, ...withoutRouting } = { ...DEFAULT_CONFIG, routing: undefined };
+		expect(validateConfig(withoutRouting)).toBe(true);
+	});
 });
 
 describe('loadConfig', () => {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -118,6 +118,12 @@ describe('validateConfig', () => {
 		const { routing: _, ...withoutRouting } = { ...DEFAULT_CONFIG, routing: undefined };
 		expect(validateConfig(withoutRouting)).toBe(true);
 	});
+
+	it('rejects config with invalid routing shape', () => {
+		expect(validateConfig({ ...DEFAULT_CONFIG, routing: 42 })).toBe(false);
+		expect(validateConfig({ ...DEFAULT_CONFIG, routing: ['/tdd'] })).toBe(false);
+		expect(validateConfig({ ...DEFAULT_CONFIG, routing: null })).toBe(false);
+	});
 });
 
 describe('loadConfig', () => {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -124,6 +124,11 @@ describe('validateConfig', () => {
 		expect(validateConfig({ ...DEFAULT_CONFIG, routing: ['/tdd'] })).toBe(false);
 		expect(validateConfig({ ...DEFAULT_CONFIG, routing: null })).toBe(false);
 	});
+
+	it('rejects config with non-string routing values', () => {
+		expect(validateConfig({ ...DEFAULT_CONFIG, routing: { key: 42 } })).toBe(false);
+		expect(validateConfig({ ...DEFAULT_CONFIG, routing: { key: null } })).toBe(false);
+	});
 });
 
 describe('loadConfig', () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -63,7 +63,10 @@ export function validateConfig(value: unknown): value is OrchestratorConfig {
 		typeof obj.notifications === 'object' &&
 		obj.notifications !== null &&
 		(obj.routing === undefined ||
-			(typeof obj.routing === 'object' && obj.routing !== null && !Array.isArray(obj.routing)))
+			(typeof obj.routing === 'object' &&
+				obj.routing !== null &&
+				!Array.isArray(obj.routing) &&
+				Object.values(obj.routing as Record<string, unknown>).every((v) => typeof v === 'string')))
 	);
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -61,7 +61,9 @@ export function validateConfig(value: unknown): value is OrchestratorConfig {
 		typeof obj.issue_source === 'object' &&
 		obj.issue_source !== null &&
 		typeof obj.notifications === 'object' &&
-		obj.notifications !== null
+		obj.notifications !== null &&
+		(obj.routing === undefined ||
+			(typeof obj.routing === 'object' && obj.routing !== null && !Array.isArray(obj.routing)))
 	);
 }
 

--- a/src/issue-fetcher.test.ts
+++ b/src/issue-fetcher.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest';
+import {
+	type ExecCommandFn,
+	extractAgentBrief,
+	fetchIssueContent,
+	formatIssueContext,
+	WORKER_CONSTRAINTS,
+} from './issue-fetcher.js';
+import type { ExecResult } from './types.js';
+
+describe('extractAgentBrief', () => {
+	it('extracts agent brief from comments with ## heading', () => {
+		const comments = JSON.stringify([
+			{ body: 'Some regular comment' },
+			{ body: '## Agent Brief\n\n- **Goal**: Do the thing\n- **Key files**: src/foo.ts' },
+		]);
+		const result = extractAgentBrief(comments);
+		expect(result).toContain('Agent Brief');
+		expect(result).toContain('Do the thing');
+	});
+
+	it('extracts agent brief with single # heading', () => {
+		const comments = JSON.stringify([{ body: '# Agent Brief\n\nSome content here' }]);
+		expect(extractAgentBrief(comments)).toContain('Agent Brief');
+	});
+
+	it('returns null when no agent brief exists', () => {
+		const comments = JSON.stringify([
+			{ body: 'Just a regular comment' },
+			{ body: 'Another comment without agent brief' },
+		]);
+		expect(extractAgentBrief(comments)).toBeNull();
+	});
+
+	it('returns null for empty comments array', () => {
+		expect(extractAgentBrief('[]')).toBeNull();
+	});
+
+	it('returns null for invalid JSON', () => {
+		expect(extractAgentBrief('not json')).toBeNull();
+	});
+
+	it('returns null for non-array JSON', () => {
+		expect(extractAgentBrief('{"body": "hi"}')).toBeNull();
+	});
+
+	it('skips comments without body field', () => {
+		const comments = JSON.stringify([{ author: 'someone' }, { body: null }]);
+		expect(extractAgentBrief(comments)).toBeNull();
+	});
+});
+
+describe('fetchIssueContent', () => {
+	function makeExec(result: ExecResult): ExecCommandFn {
+		return async () => result;
+	}
+
+	const successResult: ExecResult = {
+		exitCode: 0,
+		stdout: JSON.stringify({
+			title: 'Pre-fetch issue body',
+			body: '## What to build\n\nSome feature spec',
+			comments: [{ body: '## Agent Brief\n\n- **Goal**: Build it' }],
+		}),
+		stderr: '',
+	};
+
+	it('returns parsed issue content on success', async () => {
+		const result = await fetchIssueContent(46, 'org/repo', '/tmp', makeExec(successResult));
+		expect(result).toEqual({
+			title: 'Pre-fetch issue body',
+			body: '## What to build\n\nSome feature spec',
+			agentBrief: '## Agent Brief\n\n- **Goal**: Build it',
+		});
+	});
+
+	it('passes correct args to execCommand', async () => {
+		let capturedArgs: { cmd: string; args: readonly string[]; cwd: string } | null = null;
+		const exec: ExecCommandFn = async (cmd, args, cwd) => {
+			capturedArgs = { cmd, args, cwd };
+			return successResult;
+		};
+
+		await fetchIssueContent(46, 'owner/repo', '/worktree', exec);
+		expect(capturedArgs).toEqual({
+			cmd: 'gh',
+			args: ['issue', 'view', '46', '--repo', 'owner/repo', '--json', 'title,body,comments'],
+			cwd: '/worktree',
+		});
+	});
+
+	it('returns null on non-zero exit code', async () => {
+		const result = await fetchIssueContent(
+			46,
+			'org/repo',
+			'/tmp',
+			makeExec({ exitCode: 1, stdout: '', stderr: 'not found' }),
+		);
+		expect(result).toBeNull();
+	});
+
+	it('returns null when execCommand throws', async () => {
+		const exec: ExecCommandFn = async () => {
+			throw new Error('network error');
+		};
+		const result = await fetchIssueContent(46, 'org/repo', '/tmp', exec);
+		expect(result).toBeNull();
+	});
+
+	it('returns null on invalid JSON stdout', async () => {
+		const result = await fetchIssueContent(
+			46,
+			'org/repo',
+			'/tmp',
+			makeExec({ exitCode: 0, stdout: 'not json', stderr: '' }),
+		);
+		expect(result).toBeNull();
+	});
+
+	it('returns empty strings for missing title/body', async () => {
+		const result = await fetchIssueContent(
+			46,
+			'org/repo',
+			'/tmp',
+			makeExec({ exitCode: 0, stdout: '{}', stderr: '' }),
+		);
+		expect(result).toEqual({ title: '', body: '', agentBrief: null });
+	});
+
+	it('returns null agentBrief when no agent brief comment', async () => {
+		const result = await fetchIssueContent(
+			46,
+			'org/repo',
+			'/tmp',
+			makeExec({
+				exitCode: 0,
+				stdout: JSON.stringify({
+					title: 'Title',
+					body: 'Body',
+					comments: [{ body: 'regular comment' }],
+				}),
+				stderr: '',
+			}),
+		);
+		expect(result?.agentBrief).toBeNull();
+	});
+});
+
+describe('formatIssueContext', () => {
+	it('formats issue content with agent brief', () => {
+		const result = formatIssueContext({
+			title: 'My Issue',
+			body: 'Some body text',
+			agentBrief: '## Agent Brief\n\n- Goal: do it',
+		});
+		expect(result).toContain('## Issue: My Issue');
+		expect(result).toContain('Some body text');
+		expect(result).toContain('---');
+		expect(result).toContain('## Agent Brief');
+	});
+
+	it('formats issue content without agent brief', () => {
+		const result = formatIssueContext({
+			title: 'My Issue',
+			body: 'Body only',
+			agentBrief: null,
+		});
+		expect(result).toContain('## Issue: My Issue');
+		expect(result).toContain('Body only');
+		expect(result).not.toContain('---');
+	});
+});
+
+describe('WORKER_CONSTRAINTS', () => {
+	it('contains non-interactive mode notice', () => {
+		expect(WORKER_CONSTRAINTS).toContain('non-interactive mode');
+	});
+
+	it('contains MCP unavailable notice', () => {
+		expect(WORKER_CONSTRAINTS).toContain('MCP tools are unavailable');
+	});
+
+	it('contains gh CLI instruction', () => {
+		expect(WORKER_CONSTRAINTS).toContain('`gh` CLI for GitHub operations');
+	});
+
+	it('contains no-cd constraint', () => {
+		expect(WORKER_CONSTRAINTS).toContain('do not `cd` elsewhere');
+	});
+});

--- a/src/issue-fetcher.ts
+++ b/src/issue-fetcher.ts
@@ -1,0 +1,96 @@
+import type { ExecResult, IssueContent } from './types.js';
+
+export type { IssueContent } from './types.js';
+
+/**
+ * System constraints injected into every worker prompt.
+ * Prevents workers from attempting interactive operations or navigating away from worktree.
+ */
+export const WORKER_CONSTRAINTS = `## System Constraints
+
+- You are in non-interactive mode. MCP tools are unavailable.
+- Use \`gh\` CLI for GitHub operations.
+- \`gh\` and \`git\` commands work from your worktree directory — do not \`cd\` elsewhere.`;
+
+/**
+ * Extract the agent brief from issue comments.
+ * Looks for a comment containing an "Agent Brief" heading.
+ * Accepts either a JSON string or a parsed array of comments.
+ */
+export function extractAgentBrief(comments: string | readonly { body?: string }[]): string | null {
+	let parsed: Array<{ body?: string }>;
+	if (typeof comments === 'string') {
+		try {
+			parsed = JSON.parse(comments) as Array<{ body?: string }>;
+		} catch {
+			return null;
+		}
+	} else {
+		parsed = [...comments];
+	}
+
+	if (!Array.isArray(parsed)) return null;
+
+	for (const comment of parsed) {
+		if (typeof comment.body === 'string' && /^##?\s+Agent Brief/m.test(comment.body)) {
+			return comment.body;
+		}
+	}
+	return null;
+}
+
+export type ExecCommandFn = (
+	cmd: string,
+	args: readonly string[],
+	cwd: string,
+) => Promise<ExecResult>;
+
+/**
+ * Pre-fetch issue content using `gh issue view`.
+ * Returns null on failure (graceful fallback).
+ */
+export async function fetchIssueContent(
+	issueNumber: number,
+	repo: string,
+	cwd: string,
+	execCommand: ExecCommandFn,
+): Promise<IssueContent | null> {
+	let result: ExecResult;
+	try {
+		result = await execCommand(
+			'gh',
+			['issue', 'view', String(issueNumber), '--repo', repo, '--json', 'title,body,comments'],
+			cwd,
+		);
+	} catch {
+		return null;
+	}
+
+	if (result.exitCode !== 0) return null;
+
+	let parsed: { title?: string; body?: string; comments?: Array<{ body?: string }> };
+	try {
+		parsed = JSON.parse(result.stdout) as typeof parsed;
+	} catch {
+		return null;
+	}
+
+	const title = typeof parsed.title === 'string' ? parsed.title : '';
+	const body = typeof parsed.body === 'string' ? parsed.body : '';
+	const agentBrief = extractAgentBrief(parsed.comments ?? []);
+
+	return { title, body, agentBrief };
+}
+
+/**
+ * Format pre-fetched issue content into a prompt section.
+ */
+export function formatIssueContext(content: IssueContent): string {
+	const parts = [`## Issue: ${content.title}`, '', content.body];
+
+	if (content.agentBrief) {
+		parts.push('', '---', '', content.agentBrief);
+	}
+
+	return parts.join('\n');
+}

--- a/src/issue-fetcher.ts
+++ b/src/issue-fetcher.ts
@@ -62,16 +62,25 @@ export async function fetchIssueContent(
 			['issue', 'view', String(issueNumber), '--repo', repo, '--json', 'title,body,comments'],
 			cwd,
 		);
-	} catch {
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		process.stderr.write(`[issue-fetcher] gh issue view failed for #${issueNumber}: ${message}\n`);
 		return null;
 	}
 
-	if (result.exitCode !== 0) return null;
+	if (result.exitCode !== 0) {
+		process.stderr.write(
+			`[issue-fetcher] gh issue view exited ${result.exitCode} for #${issueNumber}: ${result.stderr}\n`,
+		);
+		return null;
+	}
 
 	let parsed: { title?: string; body?: string; comments?: Array<{ body?: string }> };
 	try {
 		parsed = JSON.parse(result.stdout) as typeof parsed;
-	} catch {
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		process.stderr.write(`[issue-fetcher] JSON parse failed for #${issueNumber}: ${message}\n`);
 		return null;
 	}
 

--- a/src/orchestrate.test.ts
+++ b/src/orchestrate.test.ts
@@ -351,6 +351,7 @@ describe('orchestrate', () => {
 			expect.any(Function),
 			undefined,
 			expect.objectContaining({ sessionId: expect.any(String), resume: false }),
+			undefined,
 		);
 	});
 });

--- a/src/orchestrate.test.ts
+++ b/src/orchestrate.test.ts
@@ -352,6 +352,7 @@ describe('orchestrate', () => {
 			undefined,
 			expect.objectContaining({ sessionId: expect.any(String), resume: false }),
 			undefined,
+			undefined,
 		);
 	});
 });

--- a/src/orchestrate.ts
+++ b/src/orchestrate.ts
@@ -1,6 +1,7 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { loadConfig as realLoadConfig } from './config.js';
+import { fetchIssueContent } from './issue-fetcher.js';
 import { parsePlan as realParsePlan } from './parser.js';
 import { hasExistingState, resumeFromState } from './resume.js';
 import { assignWork, getReadyGroups } from './scheduler.js';
@@ -89,7 +90,7 @@ function wrapSpawnWorker(
 	original: SchedulerDeps['spawnWorker'],
 	registry: WorkerRegistry,
 ): SchedulerDeps['spawnWorker'] {
-	return (issue, groupSlug, worktreePath, onEvent, contextContent?, session?) => {
+	return (issue, groupSlug, worktreePath, onEvent, contextContent?, session?, issueContent?) => {
 		let pid = -1;
 		const wrappedOnEvent = (event: WorkerEvent): void => {
 			if (event.event === 'exited') {
@@ -105,6 +106,7 @@ function wrapSpawnWorker(
 			wrappedOnEvent,
 			contextContent,
 			session,
+			issueContent,
 		);
 		pid = handle.pid;
 		registry.register(pid);
@@ -226,8 +228,25 @@ function buildRealDeps(): SchedulerDeps {
 	return {
 		createWorktree: realCreate,
 		removeWorktree: realRemove,
-		spawnWorker: (issue, groupSlug, worktreePath, onEvent, contextContent?, session?) =>
-			realSpawnWorker(issue, groupSlug, worktreePath, onEvent, contextContent, undefined, session),
+		spawnWorker: (
+			issue,
+			groupSlug,
+			worktreePath,
+			onEvent,
+			contextContent?,
+			session?,
+			issueContent?,
+		) =>
+			realSpawnWorker(
+				issue,
+				groupSlug,
+				worktreePath,
+				onEvent,
+				contextContent,
+				undefined,
+				session,
+				issueContent,
+			),
 		spawnDirectWorker: realSpawnDirectWorker,
 		killWorker: realKillWorker,
 		verify: realVerify,
@@ -240,6 +259,10 @@ function buildRealDeps(): SchedulerDeps {
 		notify: realNotify,
 		createSession: realCreateSession,
 		getSessionId: realGetSessionId,
+		fetchIssueContent: (issueNumber, cwd) => {
+			const config = realLoadConfig();
+			return fetchIssueContent(issueNumber, config.issue_source.repo, cwd, realExecCommand);
+		},
 	};
 }
 

--- a/src/orchestrate.ts
+++ b/src/orchestrate.ts
@@ -4,6 +4,10 @@ import { loadConfig as realLoadConfig } from './config.js';
 import { parsePlan as realParsePlan } from './parser.js';
 import { hasExistingState, resumeFromState } from './resume.js';
 import { assignWork, getReadyGroups } from './scheduler.js';
+import {
+	createSession as realCreateSession,
+	getSessionId as realGetSessionId,
+} from './session-manager.js';
 import type { WorkerRegistry } from './shutdown.js';
 import { createWorkerRegistry, forceKillAll, readShutdownFile } from './shutdown.js';
 import {
@@ -27,7 +31,6 @@ import type {
 	WorkerEvent,
 } from './types.js';
 import { verify as realVerify } from './verification.js';
-import { createSession as realCreateSession, getSessionId as realGetSessionId } from './session-manager.js';
 import {
 	killWorker as realKillWorker,
 	spawnDirectWorker as realSpawnDirectWorker,
@@ -95,7 +98,14 @@ function wrapSpawnWorker(
 			handleToolActivity(event, groupSlug);
 			onEvent(event);
 		};
-		const handle = original(issue, groupSlug, worktreePath, wrappedOnEvent, contextContent, session);
+		const handle = original(
+			issue,
+			groupSlug,
+			worktreePath,
+			wrappedOnEvent,
+			contextContent,
+			session,
+		);
 		pid = handle.pid;
 		registry.register(pid);
 		return handle;

--- a/src/orchestrate.ts
+++ b/src/orchestrate.ts
@@ -90,7 +90,16 @@ function wrapSpawnWorker(
 	original: SchedulerDeps['spawnWorker'],
 	registry: WorkerRegistry,
 ): SchedulerDeps['spawnWorker'] {
-	return (issue, groupSlug, worktreePath, onEvent, contextContent?, session?, issueContent?) => {
+	return (
+		issue,
+		groupSlug,
+		worktreePath,
+		onEvent,
+		contextContent?,
+		session?,
+		issueContent?,
+		route?,
+	) => {
 		let pid = -1;
 		const wrappedOnEvent = (event: WorkerEvent): void => {
 			if (event.event === 'exited') {
@@ -107,6 +116,7 @@ function wrapSpawnWorker(
 			contextContent,
 			session,
 			issueContent,
+			route,
 		);
 		pid = handle.pid;
 		registry.register(pid);
@@ -142,7 +152,7 @@ export async function orchestrate(
 	const config = (overrides?.loadConfig ?? realLoadConfig)();
 	const plan = await (overrides?.parsePlan ?? realParsePlan)(planPath);
 
-	const rawDeps = overrides?.deps ?? buildRealDeps();
+	const rawDeps = overrides?.deps ?? buildRealDeps(config.issue_source.repo);
 	const progressDeps = wrapWithProgress(rawDeps, onProgress);
 
 	// Create worker PID registry for force shutdown
@@ -224,7 +234,7 @@ async function realExecCommand(
 	}
 }
 
-function buildRealDeps(): SchedulerDeps {
+function buildRealDeps(repo: string): SchedulerDeps {
 	return {
 		createWorktree: realCreate,
 		removeWorktree: realRemove,
@@ -236,6 +246,7 @@ function buildRealDeps(): SchedulerDeps {
 			contextContent?,
 			session?,
 			issueContent?,
+			route?,
 		) =>
 			realSpawnWorker(
 				issue,
@@ -246,6 +257,7 @@ function buildRealDeps(): SchedulerDeps {
 				undefined,
 				session,
 				issueContent,
+				route,
 			),
 		spawnDirectWorker: realSpawnDirectWorker,
 		killWorker: realKillWorker,
@@ -260,8 +272,7 @@ function buildRealDeps(): SchedulerDeps {
 		createSession: realCreateSession,
 		getSessionId: realGetSessionId,
 		fetchIssueContent: (issueNumber, cwd) => {
-			const config = realLoadConfig();
-			return fetchIssueContent(issueNumber, config.issue_source.repo, cwd, realExecCommand);
+			return fetchIssueContent(issueNumber, repo, cwd, realExecCommand);
 		},
 	};
 }

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -216,6 +216,39 @@ Some description with no PR groups.
 		expect(result.groups[0]?.issues[0]?.number).toBe(5);
 	});
 
+	it('extracts optional route field from PR group', async () => {
+		const content = `# Plan
+
+## PR 1: Routed Group
+
+**Branch:** \`feat/routed\`
+**Status:** pending
+**Route:** \`/tdd\`
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| #10 | Some task | Open |
+`;
+		const result = await parsePlan(writePlan(content));
+		expect(result.groups[0]?.route).toBe('/tdd');
+	});
+
+	it('leaves route undefined when not specified', async () => {
+		const content = `# Plan
+
+## PR 1: No Route
+
+**Branch:** \`feat/no-route\`
+**Status:** pending
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| #10 | Some task | Open |
+`;
+		const result = await parsePlan(writePlan(content));
+		expect(result.groups[0]?.route).toBeUndefined();
+	});
+
 	it('parses standalone heading case-insensitively', async () => {
 		const content = `# Plan
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -4,6 +4,7 @@ import type { IssueFetcher, IssueRef, PlanData, PRGroup, PRGroupStatus } from '.
 const PR_HEADING_RE = /^## PR (\d+): (.+)$/;
 const BRANCH_RE = /\*\*Branch:\*\*\s*`([^`]+)`/;
 const STATUS_RE = /\*\*Status:\*\*\s*(\w[\w-]*)/;
+const ROUTE_RE = /\*\*Route:\*\*\s*`([^`]+)`/;
 const ISSUE_REF_RE = /\| #(\d+) \|/;
 const DEPENDS_ON_RE = /^>\s*Depends on:\s*(.+)$/;
 const STANDALONE_RE = /^## Standalone\s*$/i;
@@ -64,6 +65,7 @@ export async function parsePlan(filePath: string): Promise<PlanData> {
 		status: PRGroupStatus;
 		issues: IssueRef[];
 		depends_on: number[];
+		route?: string;
 	} | null = null;
 
 	let inStandalone = false;
@@ -115,6 +117,12 @@ export async function parsePlan(filePath: string): Promise<PlanData> {
 			const statusMatch = STATUS_RE.exec(line);
 			if (statusMatch && isValidStatus(statusMatch[1])) {
 				currentGroup = { ...currentGroup, status: statusMatch[1] };
+				continue;
+			}
+
+			const routeMatch = ROUTE_RE.exec(line);
+			if (routeMatch) {
+				currentGroup = { ...currentGroup, route: routeMatch[1] };
 				continue;
 			}
 

--- a/src/retry-coordinator.ts
+++ b/src/retry-coordinator.ts
@@ -58,6 +58,7 @@ export async function executeWithRetry(
 	config: OrchestratorConfig,
 	deps: RetryDeps,
 	issueContent?: IssueContent,
+	route?: string,
 ): Promise<RetryResult> {
 	const maxRetries = config.max_retries_on_fail;
 	const now = deps.now ?? (() => new Date().toISOString());
@@ -99,6 +100,7 @@ export async function executeWithRetry(
 						contextContent,
 						sessionId ? { sessionId, resume: isRetry } : undefined,
 						issueContent,
+						route,
 					);
 				} catch (err) {
 					reject(err);

--- a/src/retry-coordinator.ts
+++ b/src/retry-coordinator.ts
@@ -1,4 +1,10 @@
-import type { GroupStatus, OrchestratorConfig, WorkerCapableDeps, WorkerEvent } from './types.js';
+import type {
+	GroupStatus,
+	IssueContent,
+	OrchestratorConfig,
+	WorkerCapableDeps,
+	WorkerEvent,
+} from './types.js';
 
 export interface RetryDeps extends WorkerCapableDeps {
 	readonly createSession: (groupSlug: string, issue: string) => string;
@@ -51,6 +57,7 @@ export async function executeWithRetry(
 	currentStatus: GroupStatus,
 	config: OrchestratorConfig,
 	deps: RetryDeps,
+	issueContent?: IssueContent,
 ): Promise<RetryResult> {
 	const maxRetries = config.max_retries_on_fail;
 	const now = deps.now ?? (() => new Date().toISOString());
@@ -91,6 +98,7 @@ export async function executeWithRetry(
 						},
 						contextContent,
 						sessionId ? { sessionId, resume: isRetry } : undefined,
+						issueContent,
 					);
 				} catch (err) {
 					reject(err);

--- a/src/routing-resolver.test.ts
+++ b/src/routing-resolver.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { resolveRoute } from './routing-resolver.js';
+
+describe('resolveRoute', () => {
+	it('returns plan override when provided', () => {
+		const result = resolveRoute({
+			planOverride: '/prp-plan → /prp-implement',
+			configRouting: { 'enhancement+ready-for-agent': '/tdd' },
+			labels: ['enhancement', 'ready-for-agent'],
+		});
+		expect(result).toBe('/prp-plan → /prp-implement');
+	});
+
+	it('returns config routing match by sorted labels', () => {
+		const result = resolveRoute({
+			configRouting: { 'bug+ready-for-agent': '/diagnose' },
+			labels: ['ready-for-agent', 'bug'],
+		});
+		expect(result).toBe('/diagnose');
+	});
+
+	it('returns null when no override and no config', () => {
+		expect(resolveRoute({})).toBeNull();
+	});
+
+	it('returns null when labels do not match any config key', () => {
+		const result = resolveRoute({
+			configRouting: { 'bug+ready-for-agent': '/diagnose' },
+			labels: ['enhancement'],
+		});
+		expect(result).toBeNull();
+	});
+
+	it('returns null when config routing exists but no labels provided', () => {
+		const result = resolveRoute({
+			configRouting: { 'bug+ready-for-agent': '/diagnose' },
+		});
+		expect(result).toBeNull();
+	});
+
+	it('plan override takes precedence over config routing match', () => {
+		const result = resolveRoute({
+			planOverride: '/custom-skill',
+			configRouting: { 'bug+ready-for-agent': '/diagnose' },
+			labels: ['bug', 'ready-for-agent'],
+		});
+		expect(result).toBe('/custom-skill');
+	});
+});

--- a/src/routing-resolver.test.ts
+++ b/src/routing-resolver.test.ts
@@ -38,6 +38,22 @@ describe('resolveRoute', () => {
 		expect(result).toBeNull();
 	});
 
+	it('returns null when labels is an empty array', () => {
+		const result = resolveRoute({
+			configRouting: { 'bug+ready-for-agent': '/diagnose' },
+			labels: [],
+		});
+		expect(result).toBeNull();
+	});
+
+	it('returns null when labels partially match a multi-label key', () => {
+		const result = resolveRoute({
+			configRouting: { 'bug+ready-for-agent': '/diagnose' },
+			labels: ['bug'],
+		});
+		expect(result).toBeNull();
+	});
+
 	it('plan override takes precedence over config routing match', () => {
 		const result = resolveRoute({
 			planOverride: '/custom-skill',

--- a/src/routing-resolver.ts
+++ b/src/routing-resolver.ts
@@ -4,6 +4,15 @@ export interface ResolveRouteOptions {
 	readonly labels?: readonly string[];
 }
 
+/**
+ * Resolve which skill/route to inject into a worker prompt.
+ *
+ * Fallback chain (first match wins):
+ * 1. Plan-level override (per PR group `route` field)
+ * 2. Config routing lookup — labels are sorted alphabetically and joined
+ *    with `+` to form the lookup key (e.g. `['bug', 'ready-for-agent']` → `"bug+ready-for-agent"`)
+ * 3. `null` — caller should use direct implementation prompt
+ */
 export function resolveRoute(options: ResolveRouteOptions): string | null {
 	if (options.planOverride) return options.planOverride;
 

--- a/src/routing-resolver.ts
+++ b/src/routing-resolver.ts
@@ -1,0 +1,17 @@
+export interface ResolveRouteOptions {
+	readonly planOverride?: string;
+	readonly configRouting?: Readonly<Record<string, string>>;
+	readonly labels?: readonly string[];
+}
+
+export function resolveRoute(options: ResolveRouteOptions): string | null {
+	if (options.planOverride) return options.planOverride;
+
+	if (options.configRouting && options.labels?.length) {
+		const key = [...options.labels].sort().join('+');
+		const match = options.configRouting[key];
+		if (match) return match;
+	}
+
+	return null;
+}

--- a/src/scheduler.test.ts
+++ b/src/scheduler.test.ts
@@ -372,7 +372,84 @@ describe('assignWork', () => {
 			expect.any(Function),
 			'Previous attempt failed due to X',
 			expect.objectContaining({ sessionId: expect.any(String) }),
+			undefined,
 		);
+	});
+
+	it('passes pre-fetched issue content to worker', async () => {
+		const issueContent = {
+			title: 'Pre-fetch test',
+			body: 'Some body',
+			agentBrief: '## Agent Brief\n\n- Goal: test',
+		};
+		const group = makeGroup({ pr_number: 1, branch: 'feat/prefetch' });
+		const deps = createMockDeps({
+			fetchIssueContent: vi.fn(async () => issueContent),
+		});
+
+		await assignWork(makePlan([group]), new Set(), BASE_CONFIG, deps, now);
+
+		expect(deps.fetchIssueContent).toHaveBeenCalledWith(10, '/tmp/wt');
+		expect(deps.spawnWorker).toHaveBeenCalledWith(
+			'10',
+			expect.any(String),
+			'/tmp/wt',
+			expect.any(Function),
+			undefined,
+			expect.objectContaining({ sessionId: expect.any(String) }),
+			issueContent,
+		);
+	});
+
+	it('spawns worker without issue content when fetchIssueContent not provided', async () => {
+		const group = makeGroup({ pr_number: 1, branch: 'feat/nofetch' });
+		const deps = createMockDeps(); // no fetchIssueContent
+
+		await assignWork(makePlan([group]), new Set(), BASE_CONFIG, deps, now);
+
+		expect(deps.spawnWorker).toHaveBeenCalledWith(
+			'10',
+			expect.any(String),
+			'/tmp/wt',
+			expect.any(Function),
+			undefined,
+			expect.objectContaining({ sessionId: expect.any(String) }),
+			undefined,
+		);
+	});
+
+	it('falls back gracefully when fetchIssueContent returns null', async () => {
+		const group = makeGroup({ pr_number: 1, branch: 'feat/fetchnull' });
+		const deps = createMockDeps({
+			fetchIssueContent: vi.fn(async () => null),
+		});
+
+		await assignWork(makePlan([group]), new Set(), BASE_CONFIG, deps, now);
+
+		expect(deps.spawnWorker).toHaveBeenCalledWith(
+			'10',
+			expect.any(String),
+			'/tmp/wt',
+			expect.any(Function),
+			undefined,
+			expect.objectContaining({ sessionId: expect.any(String) }),
+			undefined,
+		);
+	});
+
+	it('falls back gracefully when fetchIssueContent throws', async () => {
+		const group = makeGroup({ pr_number: 1, branch: 'feat/fetcherr' });
+		const deps = createMockDeps({
+			fetchIssueContent: vi.fn(async () => {
+				throw new Error('network failure');
+			}),
+		});
+
+		const result = await assignWork(makePlan([group]), new Set(), BASE_CONFIG, deps, now);
+
+		// Worker still spawns — pre-fetch failure is non-fatal
+		expect(deps.spawnWorker).toHaveBeenCalled();
+		expect(result.results[0]?.completed).toBe(true);
 	});
 
 	it('deletes context on success', async () => {

--- a/src/scheduler.test.ts
+++ b/src/scheduler.test.ts
@@ -373,6 +373,7 @@ describe('assignWork', () => {
 			'Previous attempt failed due to X',
 			expect.objectContaining({ sessionId: expect.any(String) }),
 			undefined,
+			undefined,
 		);
 	});
 
@@ -398,6 +399,7 @@ describe('assignWork', () => {
 			undefined,
 			expect.objectContaining({ sessionId: expect.any(String) }),
 			issueContent,
+			undefined,
 		);
 	});
 
@@ -414,6 +416,7 @@ describe('assignWork', () => {
 			expect.any(Function),
 			undefined,
 			expect.objectContaining({ sessionId: expect.any(String) }),
+			undefined,
 			undefined,
 		);
 	});
@@ -434,6 +437,7 @@ describe('assignWork', () => {
 			undefined,
 			expect.objectContaining({ sessionId: expect.any(String) }),
 			undefined,
+			undefined,
 		);
 	});
 
@@ -450,6 +454,48 @@ describe('assignWork', () => {
 		// Worker still spawns — pre-fetch failure is non-fatal
 		expect(deps.spawnWorker).toHaveBeenCalled();
 		expect(result.results[0]?.completed).toBe(true);
+	});
+
+	it('passes plan-level route to worker', async () => {
+		const group = makeGroup({ pr_number: 1, branch: 'feat/routed', route: '/tdd' });
+		const deps = createMockDeps();
+
+		await assignWork(makePlan([group]), new Set(), BASE_CONFIG, deps, now);
+
+		expect(deps.spawnWorker).toHaveBeenCalledWith(
+			'10',
+			expect.any(String),
+			'/tmp/wt',
+			expect.any(Function),
+			undefined,
+			expect.objectContaining({ sessionId: expect.any(String) }),
+			undefined,
+			'/tdd',
+		);
+	});
+
+	it('does not apply config routing without labels (label-based routing not yet wired)', async () => {
+		const group = makeGroup({ pr_number: 1, branch: 'feat/configroute' });
+		const configWithRouting = {
+			...BASE_CONFIG,
+			routing: { 'enhancement+ready-for-agent': '/pick-up' },
+		};
+		const deps = createMockDeps();
+
+		await assignWork(makePlan([group]), new Set(), configWithRouting, deps, now);
+
+		// Config routing requires labels, which are not yet available in PlanData.
+		// Only plan-level group.route is wired; config routing is infrastructure for future use.
+		expect(deps.spawnWorker).toHaveBeenCalledWith(
+			'10',
+			expect.any(String),
+			'/tmp/wt',
+			expect.any(Function),
+			undefined,
+			expect.objectContaining({ sessionId: expect.any(String) }),
+			undefined,
+			undefined,
+		);
 	});
 
 	it('deletes context on success', async () => {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -8,6 +8,7 @@ import type {
 	AssignWorkResult,
 	ExecResult,
 	GroupStatus,
+	IssueContent,
 	MergeDetectorDeps,
 	MergeDetectorResult,
 	OrchestratorConfig,
@@ -220,6 +221,22 @@ async function processIssue(
 			return { success: false, error: installResult.error };
 		}
 
+		// Pre-fetch issue content (graceful fallback on failure)
+		let issueContent: IssueContent | undefined;
+		if (deps.fetchIssueContent) {
+			try {
+				const fetched = await deps.fetchIssueContent(issueNumber, worktreeInfo.worktreePath);
+				if (fetched) {
+					issueContent = fetched;
+				}
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				process.stderr.write(
+					`[scheduler] issue pre-fetch failed for #${issueNumber}: ${message}\n`,
+				);
+			}
+		}
+
 		// coding
 		safeWriteStatus(deps, slug, {
 			...freshStatus(slug, group, deps, now),
@@ -237,6 +254,7 @@ async function processIssue(
 			currentStatus,
 			config,
 			coreWorkerDeps(deps, now),
+			issueContent,
 		);
 
 		if (!retryResult.success) {

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -2,6 +2,7 @@ import { startMergeDetector } from './merge-detector.js';
 import { buildPRBody, pushAndCreatePR } from './pr-creator.js';
 import { prReview } from './pr-reviewer.js';
 import { executeWithRetry, type RetryDeps } from './retry-coordinator.js';
+import { resolveRoute } from './routing-resolver.js';
 import { selfReview } from './self-reviewer.js';
 import { deriveSlug } from './slug.js';
 import type {
@@ -221,6 +222,16 @@ async function processIssue(
 			return { success: false, error: installResult.error };
 		}
 
+		// Resolve route for this issue.
+		// Label-based routing (config.routing + labels) is not yet wired — labels
+		// are GitHub metadata not currently available in PlanData. Only plan-level
+		// overrides (group.route) are resolved for now.
+		const route =
+			resolveRoute({
+				planOverride: group.route,
+				configRouting: config.routing,
+			}) ?? undefined;
+
 		// Pre-fetch issue content (graceful fallback on failure)
 		let issueContent: IssueContent | undefined;
 		if (deps.fetchIssueContent) {
@@ -255,6 +266,7 @@ async function processIssue(
 			config,
 			coreWorkerDeps(deps, now),
 			issueContent,
+			route,
 		);
 
 		if (!retryResult.success) {

--- a/src/tui/Dashboard.test.tsx
+++ b/src/tui/Dashboard.test.tsx
@@ -226,7 +226,12 @@ describe('MainView', () => {
 describe('Footer', () => {
 	it('shows keybinding hints with default state', () => {
 		const { lastFrame } = render(
-			React.createElement(Footer, { activePanel: 0, screenMode: 'normal', overlay: 'none' }),
+			React.createElement(Footer, {
+				activePanel: 0,
+				screenMode: 'normal',
+				overlay: 'none',
+				shutdownStatus: 'none',
+			}),
 		);
 		const frame = lastFrame();
 		expect(frame).toContain('quit');
@@ -237,35 +242,60 @@ describe('Footer', () => {
 
 	it('shows contextual j/k label for groups panel', () => {
 		const { lastFrame } = render(
-			React.createElement(Footer, { activePanel: 0, screenMode: 'normal', overlay: 'none' }),
+			React.createElement(Footer, {
+				activePanel: 0,
+				screenMode: 'normal',
+				overlay: 'none',
+				shutdownStatus: 'none',
+			}),
 		);
 		expect(lastFrame()).toContain('group');
 	});
 
 	it('shows contextual j/k label for issues panel', () => {
 		const { lastFrame } = render(
-			React.createElement(Footer, { activePanel: 1, screenMode: 'normal', overlay: 'none' }),
+			React.createElement(Footer, {
+				activePanel: 1,
+				screenMode: 'normal',
+				overlay: 'none',
+				shutdownStatus: 'none',
+			}),
 		);
 		expect(lastFrame()).toContain('issue');
 	});
 
 	it('hides j/k hint for activity panel', () => {
 		const { lastFrame } = render(
-			React.createElement(Footer, { activePanel: 2, screenMode: 'normal', overlay: 'none' }),
+			React.createElement(Footer, {
+				activePanel: 2,
+				screenMode: 'normal',
+				overlay: 'none',
+				shutdownStatus: 'none',
+			}),
 		);
 		expect(lastFrame()).not.toContain('j/k');
 	});
 
 	it('reflects active overlay in hints', () => {
 		const { lastFrame } = render(
-			React.createElement(Footer, { activePanel: 0, screenMode: 'normal', overlay: 'deps' }),
+			React.createElement(Footer, {
+				activePanel: 0,
+				screenMode: 'normal',
+				overlay: 'deps',
+				shutdownStatus: 'none',
+			}),
 		);
 		expect(lastFrame()).toContain('deps:on');
 	});
 
 	it('shows next mode in + hint', () => {
 		const { lastFrame } = render(
-			React.createElement(Footer, { activePanel: 0, screenMode: 'half', overlay: 'none' }),
+			React.createElement(Footer, {
+				activePanel: 0,
+				screenMode: 'half',
+				overlay: 'none',
+				shutdownStatus: 'none',
+			}),
 		);
 		// half → next is full
 		expect(lastFrame()).toContain('layout:full');

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ export interface OrchestratorConfig {
 	readonly rule_files: readonly string[];
 	readonly issue_source: IssueSource;
 	readonly notifications: NotificationConfig;
+	readonly routing?: Readonly<Record<string, string>>;
 }
 
 export type AgentState = 'queued' | 'in_progress' | 'done' | 'failed';
@@ -61,6 +62,7 @@ export interface PRGroup {
 	readonly status: PRGroupStatus;
 	readonly issues: readonly IssueRef[];
 	readonly depends_on: readonly number[];
+	readonly route?: string;
 }
 
 export interface PlanData {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,9 @@
+export interface IssueContent {
+	readonly title: string;
+	readonly body: string;
+	readonly agentBrief: string | null;
+}
+
 export interface VerifyCommand {
 	readonly name: string;
 	readonly command: string;
@@ -140,6 +146,7 @@ export interface SchedulerDeps {
 		onEvent: (event: WorkerEvent) => void,
 		contextContent?: string,
 		session?: SessionOptions,
+		issueContent?: IssueContent,
 	) => WorkerHandle;
 	readonly spawnDirectWorker: (
 		id: string,
@@ -160,6 +167,7 @@ export interface SchedulerDeps {
 	readonly shouldShutdown?: () => ShutdownSignal | null;
 	readonly createSession: (groupSlug: string, issue: string) => string;
 	readonly getSessionId: (groupSlug: string, issue: string) => string | null;
+	readonly fetchIssueContent?: (issueNumber: number, cwd: string) => Promise<IssueContent | null>;
 }
 
 export interface GroupResult {
@@ -234,6 +242,7 @@ export interface WorkerCapableDeps {
 		onEvent: (event: WorkerEvent) => void,
 		contextContent?: string,
 		session?: SessionOptions,
+		issueContent?: IssueContent,
 	) => WorkerHandle;
 	readonly spawnDirectWorker: (
 		id: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -147,6 +147,7 @@ export interface SchedulerDeps {
 		contextContent?: string,
 		session?: SessionOptions,
 		issueContent?: IssueContent,
+		route?: string,
 	) => WorkerHandle;
 	readonly spawnDirectWorker: (
 		id: string,
@@ -243,6 +244,7 @@ export interface WorkerCapableDeps {
 		contextContent?: string,
 		session?: SessionOptions,
 		issueContent?: IssueContent,
+		route?: string,
 	) => WorkerHandle;
 	readonly spawnDirectWorker: (
 		id: string,

--- a/src/worker-manager.test.ts
+++ b/src/worker-manager.test.ts
@@ -56,40 +56,47 @@ function createFakeProc(pid: number | undefined = 12345): FakeProc {
 
 describe('buildPrompt', () => {
 	it('builds direct implementation prompt without context', () => {
-		expect(buildPrompt('10')).toBe('Implement issue #10');
+		const result = buildPrompt('10');
+		expect(result).toContain('Implement issue #10');
+		expect(result).toContain('non-interactive mode');
 	});
 
 	it('builds prompt with context', () => {
 		const result = buildPrompt('10', 'Previous approach failed due to X');
-		expect(result).toBe(
-			'Implement issue #10\n\nContext from previous attempt:\nPrevious approach failed due to X',
-		);
+		expect(result).toContain('Implement issue #10');
+		expect(result).toContain('Context from previous attempt:\nPrevious approach failed due to X');
+		expect(result).toContain('non-interactive mode');
 	});
 
 	it('handles empty context as no context', () => {
-		expect(buildPrompt('5', '')).toBe('Implement issue #5');
+		const result = buildPrompt('5', '');
+		expect(result).toContain('Implement issue #5');
+		expect(result).not.toContain('Context from previous attempt');
 	});
 
 	it('builds resume prompt with session-resumed context', () => {
 		const result = buildPrompt('10', 'worker exited with code 1', { resume: true });
-		expect(result).toBe(
-			'Implement issue #10\n\nContext from previous attempt (session resumed):\nworker exited with code 1',
-		);
+		expect(result).toContain('Implement issue #10');
+		expect(result).toContain('Context from previous attempt (session resumed):');
+		expect(result).toContain('worker exited with code 1');
 	});
 
 	it('builds normal prompt when resume set but no context', () => {
 		const result = buildPrompt('10', undefined, { resume: true });
-		expect(result).toBe('Implement issue #10');
+		expect(result).toContain('Implement issue #10');
+		expect(result).not.toContain('Context from previous attempt');
 	});
 
 	it('uses route as prompt prefix when provided', () => {
 		const result = buildPrompt('10', undefined, { route: '/pick-up' });
-		expect(result).toBe('/pick-up #10');
+		expect(result).toContain('/pick-up #10');
+		expect(result).toContain('non-interactive mode');
 	});
 
 	it('uses route with context', () => {
 		const result = buildPrompt('10', 'some context', { route: '/tdd' });
-		expect(result).toBe('/tdd #10\n\nContext from previous attempt:\nsome context');
+		expect(result).toContain('/tdd #10');
+		expect(result).toContain('Context from previous attempt:\nsome context');
 	});
 
 	it('uses route with resume context', () => {
@@ -133,6 +140,14 @@ describe('buildPrompt', () => {
 		expect(result).toContain('/tdd #46');
 		expect(result).toContain('## Issue: Title');
 		expect(result).toContain('non-interactive mode');
+	});
+
+	it('always includes constraints even without issueContent', () => {
+		const result = buildPrompt('10');
+		expect(result).toContain('## System Constraints');
+		expect(result).toContain('non-interactive mode');
+		expect(result).toContain('do not `cd` elsewhere');
+		expect(result).not.toContain('## Issue:');
 	});
 });
 
@@ -447,7 +462,13 @@ describe('spawnWorker', () => {
 
 		expect(spawnMock).toHaveBeenCalledWith(
 			'claude',
-			['-p', '--verbose', '--output-format', 'stream-json', 'Implement issue #10'],
+			[
+				'-p',
+				'--verbose',
+				'--output-format',
+				'stream-json',
+				expect.stringContaining('Implement issue #10'),
+			],
 			expect.objectContaining({
 				cwd: tmpDir,
 				stdio: ['ignore', 'pipe', 'pipe'],
@@ -457,6 +478,9 @@ describe('spawnWorker', () => {
 				}),
 			}),
 		);
+		// Verify constraints are in the prompt
+		const prompt = (spawnMock.mock.calls[0]?.[1] as string[])?.[4];
+		expect(prompt).toContain('non-interactive mode');
 	});
 
 	it('emits spawned event via nextTick', async () => {
@@ -562,17 +586,10 @@ describe('spawnWorker', () => {
 
 		spawnWorker('10', 'pr-1', tmpDir, () => {}, 'Previous context here', tmpDir);
 
-		expect(spawnMock).toHaveBeenCalledWith(
-			'claude',
-			[
-				'-p',
-				'--verbose',
-				'--output-format',
-				'stream-json',
-				'Implement issue #10\n\nContext from previous attempt:\nPrevious context here',
-			],
-			expect.anything(),
-		);
+		const prompt = (spawnMock.mock.calls[0]?.[1] as string[])?.[4] ?? '';
+		expect(prompt).toContain('Implement issue #10');
+		expect(prompt).toContain('Context from previous attempt:\nPrevious context here');
+		expect(prompt).toContain('non-interactive mode');
 	});
 
 	it('includes --session-id flag on first spawn when sessionId provided', () => {

--- a/src/worker-manager.test.ts
+++ b/src/worker-manager.test.ts
@@ -55,32 +55,41 @@ function createFakeProc(pid: number | undefined = 12345): FakeProc {
 }
 
 describe('buildPrompt', () => {
-	it('builds basic prompt without context', () => {
-		expect(buildPrompt('10')).toBe('/pick-up #10');
+	it('builds direct implementation prompt without context', () => {
+		expect(buildPrompt('10')).toBe('Implement issue #10');
 	});
 
 	it('builds prompt with context', () => {
 		const result = buildPrompt('10', 'Previous approach failed due to X');
 		expect(result).toBe(
-			'/pick-up #10\n\nContext from previous attempt:\nPrevious approach failed due to X',
+			'Implement issue #10\n\nContext from previous attempt:\nPrevious approach failed due to X',
 		);
 	});
 
 	it('handles empty context as no context', () => {
-		expect(buildPrompt('5', '')).toBe('/pick-up #5');
+		expect(buildPrompt('5', '')).toBe('Implement issue #5');
 	});
 
-	it('builds resume prompt with /pick-up and session-resumed context', () => {
+	it('builds resume prompt with session-resumed context', () => {
 		const result = buildPrompt('10', 'worker exited with code 1', { resume: true });
 		expect(result).toBe(
-			'/pick-up #10\n\nContext from previous attempt (session resumed):\nworker exited with code 1',
+			'Implement issue #10\n\nContext from previous attempt (session resumed):\nworker exited with code 1',
 		);
-		expect(result).toContain('/pick-up');
 	});
 
 	it('builds normal prompt when resume set but no context', () => {
 		const result = buildPrompt('10', undefined, { resume: true });
+		expect(result).toBe('Implement issue #10');
+	});
+
+	it('uses route as prompt prefix when provided', () => {
+		const result = buildPrompt('10', undefined, { route: '/pick-up' });
 		expect(result).toBe('/pick-up #10');
+	});
+
+	it('uses route with context', () => {
+		const result = buildPrompt('10', 'some context', { route: '/tdd' });
+		expect(result).toBe('/tdd #10\n\nContext from previous attempt:\nsome context');
 	});
 });
 
@@ -395,7 +404,7 @@ describe('spawnWorker', () => {
 
 		expect(spawnMock).toHaveBeenCalledWith(
 			'claude',
-			['-p', '--verbose', '--output-format', 'stream-json', '/pick-up #10'],
+			['-p', '--verbose', '--output-format', 'stream-json', 'Implement issue #10'],
 			expect.objectContaining({
 				cwd: tmpDir,
 				stdio: ['ignore', 'pipe', 'pipe'],
@@ -517,7 +526,7 @@ describe('spawnWorker', () => {
 				'--verbose',
 				'--output-format',
 				'stream-json',
-				'/pick-up #10\n\nContext from previous attempt:\nPrevious context here',
+				'Implement issue #10\n\nContext from previous attempt:\nPrevious context here',
 			],
 			expect.anything(),
 		);

--- a/src/worker-manager.test.ts
+++ b/src/worker-manager.test.ts
@@ -94,9 +94,45 @@ describe('buildPrompt', () => {
 
 	it('uses route with resume context', () => {
 		const result = buildPrompt('10', 'worker exited', { route: '/tdd', resume: true });
-		expect(result).toBe(
-			'/tdd #10\n\nContext from previous attempt (session resumed):\nworker exited',
-		);
+		expect(result).toContain('/tdd #10');
+		expect(result).toContain('Context from previous attempt (session resumed):');
+		expect(result).toContain('worker exited');
+	});
+
+	it('includes issue content and constraints when issueContent provided', () => {
+		const result = buildPrompt('46', undefined, {
+			issueContent: {
+				title: 'Pre-fetch issue body',
+				body: '## What to build\n\nSome spec',
+				agentBrief: '## Agent Brief\n\n- Goal: build it',
+			},
+		});
+		expect(result).toContain('Implement issue #46');
+		expect(result).toContain('## Issue: Pre-fetch issue body');
+		expect(result).toContain('## What to build');
+		expect(result).toContain('## Agent Brief');
+		expect(result).toContain('non-interactive mode');
+		expect(result).toContain('do not `cd` elsewhere');
+	});
+
+	it('includes both issue content and retry context', () => {
+		const result = buildPrompt('46', 'failed: lint', {
+			issueContent: { title: 'Title', body: 'Body', agentBrief: null },
+		});
+		expect(result).toContain('## Issue: Title');
+		expect(result).toContain('non-interactive mode');
+		expect(result).toContain('Context from previous attempt:');
+		expect(result).toContain('failed: lint');
+	});
+
+	it('includes issue content with route', () => {
+		const result = buildPrompt('46', undefined, {
+			route: '/tdd',
+			issueContent: { title: 'Title', body: 'Body', agentBrief: null },
+		});
+		expect(result).toContain('/tdd #46');
+		expect(result).toContain('## Issue: Title');
+		expect(result).toContain('non-interactive mode');
 	});
 });
 

--- a/src/worker-manager.test.ts
+++ b/src/worker-manager.test.ts
@@ -91,6 +91,13 @@ describe('buildPrompt', () => {
 		const result = buildPrompt('10', 'some context', { route: '/tdd' });
 		expect(result).toBe('/tdd #10\n\nContext from previous attempt:\nsome context');
 	});
+
+	it('uses route with resume context', () => {
+		const result = buildPrompt('10', 'worker exited', { route: '/tdd', resume: true });
+		expect(result).toBe(
+			'/tdd #10\n\nContext from previous attempt (session resumed):\nworker exited',
+		);
+	});
 });
 
 describe('getLogDir', () => {

--- a/src/worker-manager.ts
+++ b/src/worker-manager.ts
@@ -32,8 +32,10 @@ export function buildPrompt(
 
 	if (options?.issueContent) {
 		parts.push('', formatIssueContext(options.issueContent));
-		parts.push('', WORKER_CONSTRAINTS);
 	}
+
+	// Always inject constraints — even if issue pre-fetch failed
+	parts.push('', WORKER_CONSTRAINTS);
 
 	if (contextContent) {
 		const label = options?.resume
@@ -331,6 +333,7 @@ export function spawnWorker(
 	baseDir?: string,
 	session?: SessionOptions,
 	issueContent?: IssueContent,
+	route?: string,
 ): WorkerHandle {
 	assertValidSlug(groupSlug);
 	assertValidIssue(issue);
@@ -339,6 +342,7 @@ export function spawnWorker(
 	const prompt = buildPrompt(issue, contextContent, {
 		resume: session?.resume,
 		issueContent,
+		route,
 	});
 	return spawnClaudeProcess(issue, groupSlug, worktreePath, prompt, onEvent, baseDir, session);
 }

--- a/src/worker-manager.ts
+++ b/src/worker-manager.ts
@@ -20,9 +20,11 @@ const KILL_POLL_INTERVAL_MS = 100;
 export function buildPrompt(
 	issueNumber: string,
 	contextContent?: string,
-	options?: { resume?: boolean },
+	options?: { resume?: boolean; route?: string },
 ): string {
-	const base = `/pick-up #${issueNumber}`;
+	const base = options?.route
+		? `${options.route} #${issueNumber}`
+		: `Implement issue #${issueNumber}`;
 	if (!contextContent) return base;
 	if (options?.resume) {
 		return `${base}\n\nContext from previous attempt (session resumed):\n${contextContent}`;
@@ -325,7 +327,7 @@ export function spawnWorker(
 }
 
 /**
- * Spawn a Claude worker with a direct prompt (no /pick-up wrapping).
+ * Spawn a Claude worker with a direct prompt (no routing or issue wrapping).
  * Used for review and fix workers that don't correspond to a numeric issue.
  */
 export function spawnDirectWorker(

--- a/src/worker-manager.ts
+++ b/src/worker-manager.ts
@@ -2,8 +2,10 @@ import { spawn } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as readline from 'node:readline';
+import { formatIssueContext, WORKER_CONSTRAINTS } from './issue-fetcher.js';
 import { parseToolUseActivity } from './tui/observability.js';
 import type {
+	IssueContent,
 	NdjsonAssistantMessage,
 	NdjsonMessage,
 	NdjsonResultMessage,
@@ -20,16 +22,27 @@ const KILL_POLL_INTERVAL_MS = 100;
 export function buildPrompt(
 	issueNumber: string,
 	contextContent?: string,
-	options?: { resume?: boolean; route?: string },
+	options?: { resume?: boolean; route?: string; issueContent?: IssueContent },
 ): string {
 	const base = options?.route
 		? `${options.route} #${issueNumber}`
 		: `Implement issue #${issueNumber}`;
-	if (!contextContent) return base;
-	if (options?.resume) {
-		return `${base}\n\nContext from previous attempt (session resumed):\n${contextContent}`;
+
+	const parts: string[] = [base];
+
+	if (options?.issueContent) {
+		parts.push('', formatIssueContext(options.issueContent));
+		parts.push('', WORKER_CONSTRAINTS);
 	}
-	return `${base}\n\nContext from previous attempt:\n${contextContent}`;
+
+	if (contextContent) {
+		const label = options?.resume
+			? 'Context from previous attempt (session resumed):'
+			: 'Context from previous attempt:';
+		parts.push('', `${label}\n${contextContent}`);
+	}
+
+	return parts.join('\n');
 }
 
 export function getLogDir(groupSlug: string, baseDir?: string): string {
@@ -317,12 +330,16 @@ export function spawnWorker(
 	contextContent?: string,
 	baseDir?: string,
 	session?: SessionOptions,
+	issueContent?: IssueContent,
 ): WorkerHandle {
 	assertValidSlug(groupSlug);
 	assertValidIssue(issue);
 	assertValidWorktreePath(worktreePath);
 
-	const prompt = buildPrompt(issue, contextContent, { resume: session?.resume });
+	const prompt = buildPrompt(issue, contextContent, {
+		resume: session?.resume,
+		issueContent,
+	});
 	return spawnClaudeProcess(issue, groupSlug, worktreePath, prompt, onEvent, baseDir, session);
 }
 


### PR DESCRIPTION
## Summary

### #45 — Remove /pick-up, add configurable routing
- Remove hardcoded `/pick-up #N` from `buildPrompt()`, replace with direct `Implement issue #N` prompt and optional `route` parameter
- Add new `routing-resolver` module with pure `resolveRoute()` function — fallback chain: plan override → config routing rules → null (direct prompt)
- Add `routing?: Record<string, string>` to `OrchestratorConfig` and `route?: string` to `PRGroup`
- Update plan parser to extract `**Route:** \`...\`` from PR group markdown

### #46 — Pre-fetch issue body + inject system prompt constraints
- Add `fetchIssueContent()` — runs `gh issue view` to pre-fetch issue title, body, and agent brief before spawning workers
- Add `WORKER_CONSTRAINTS` constant injected into every worker prompt (non-interactive mode, no MCP, use gh CLI, no cd)
- Expand `buildPrompt()` to include pre-fetched issue context and constraints block
- Wire through scheduler → retry-coordinator → spawnWorker → real deps in orchestrate.ts
- Graceful fallback: fetch failure logs warning, worker still spawns with just issue number

## Test plan

- [x] Routing resolver: plan override wins over config
- [x] Routing resolver: config routing lookup by sorted labels
- [x] Routing resolver: fallback to null when no match
- [x] buildPrompt: direct prompt without /pick-up
- [x] buildPrompt: route param used as prefix
- [x] buildPrompt: includes issue content + constraints when provided
- [x] buildPrompt: includes both issue content and retry context
- [x] buildPrompt: includes issue content with route
- [x] Parser: extracts route field from PR group
- [x] fetchIssueContent: returns parsed content on success
- [x] fetchIssueContent: returns null on failure (exit code, network error, bad JSON)
- [x] extractAgentBrief: finds Agent Brief heading in comments
- [x] extractAgentBrief: handles missing/invalid input
- [x] formatIssueContext: formats with and without agent brief
- [x] WORKER_CONSTRAINTS: contains all required constraint lines
- [x] Scheduler: passes pre-fetched content to worker
- [x] Scheduler: graceful fallback when fetch returns null
- [x] Scheduler: graceful fallback when fetch throws
- [x] Scheduler: works without fetchIssueContent dep
- [x] All 648 tests pass, lint clean, typecheck clean

Closes #45
Closes #46